### PR TITLE
Fix DataInputStream.readUTF() panic on non-UTF-8 (EUC-KR) input

### DIFF
--- a/java_runtime/src/classes/java/io/data_input_stream.rs
+++ b/java_runtime/src/classes/java/io/data_input_stream.rs
@@ -185,8 +185,15 @@ impl DataInputStream {
         let mut buf = vec![0; length as _];
         jvm.array_raw_buffer(&java_array).await?.read(0, &mut buf)?;
 
-        // TODO handle modified utf-8
-        let string = RustString::from_utf8(buf).unwrap();
+        // TODO handle modified utf-8 (EUC-KR fallback)
+        let string = match RustString::from_utf8(buf) {
+            Ok(x) => x,
+            Err(e) => {
+                let bytes = e.into_bytes();
+                let (decoded, _, _) = encoding_rs::EUC_KR.decode(&bytes);
+                decoded.into_owned()
+            }
+        };
 
         Ok(JavaLangString::from_rust_string(jvm, &string).await?.into())
     }


### PR DESCRIPTION
`[KTF] 타워크래프트` 같은 게임이 아래와 같이 크래시가 납니다.

```
./target/debug/wie_cli ./타워크래프트.zip                                                                                 
Height1:320                                                                                                                   
Height2:320                                                                                                                   
Annunciator Height:0                                                                                                          
Card width, height == 240, 320                                                                                                
레코드가 없으므로 생성시킨다                                                                                                  
레코드가 없으므로 생성시킨다                                                                                                  
레코드가 없으므로 생성시킨다                                                                                                  
레코드가 없으므로 생성시킨다                                                                                                  
레코드가 없으므로 생성시킨다                                                                                                  
레코드가 없으므로 생성시킨다                                                                                                  
DB open 실행완료                                                                                                              
LoadRecord[0] 에 -100 이 있으므로 null 리턴                                                                                   
FileTest 에 F_byte 에 null 이 넘어왔다                                                                                        
file open : savetower                                                                                                         
LoadRecord[0] 에 -100 이 있으므로 null 리턴                                                                                   
FilOpen 에 F_byte 에 null 이 넘어왔다                                                                                         
file open : userdata1                                                                                                         
LoadRecord[0] 에 -100 이 있으므로 null 리턴                                                                                   
FilOpen 에 F_byte 에 null 이 넘어왔다                                                                                         
file open : userdata2                                                                                                         
LoadRecord[0] 에 -100 이 있으므로 null 리턴                                                                                   
FilOpen 에 F_byte 에 null 이 넘어왔다                                                                                         
file open : userdata3                                                                                                         
LoadRecord[0] 에 -100 이 있으므로 null 리턴                                                                                   
FilOpen 에 F_byte 에 null 이 넘어왔다                                                                                         
file open : userdata4                                                                                                         
LoadRecord[0] 에 -100 이 있으므로 null 리턴                                                                                   
FilOpen 에 F_byte 에 null 이 넘어왔다                                                                                         
file open : strdata                                                                                                           
LoadRecord[0] 에 -100 이 있으므로 null 리턴                                                                                   
FilOpen 에 F_byte 에 null 이 넘어왔다                                                                                         
file open : strdata                                                                                                           
LoadRecord[0] 에 다른 값이 있으므로 값 리턴                                                                                   
FilOpen 에 F_input 이 생성된다                                                                                                
                                                                                                                              
thread 'main' (35722347) panicked at /Users/redacted/.cargo/git/checkouts/rustjava-b78e8f47b488d719/9796297/java_runtime/s 
rc/classes/java/io/data_input_stream.rs:189:49:                                                                               
called `Result::unwrap()` on an `Err` value: FromUtf8Error { bytes: [186, 243, 32, 189, 189, 183, 212], error: Utf8Error {    
valid_up_to: 0, error_len: Some(1) } }                                                                                        
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace                                                 
                                                                                                                              
thread 'main' (35722347) panicked at library/core/src/panicking.rs:225:5:                                                     
panic in a function that cannot unwind                                                                                        
stack backtrace:                                                                                                              
   0:        0x104698c54 - std::backtrace_rs::backtrace::libunwind::trace::hfe3c1738a677a156                                  
                               at                                                                                             
/rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library/std/src/../../backtrace/src/backtrace/libunwind.rs:117:9              
   1:        0x104698c54 - std::backtrace_rs::backtrace::trace_unsynchronized::hf7190cd5d3f4ec8a                              
                               at                                                                                             
/rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library/std/src/../../backtrace/src/backtrace/mod.rs:66:14                    
   2:        0x104698c54 - std::sys::backtrace::_print_fmt::h7fdb185d3ec06757                                                 
                               at /rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library/std/src/sys/backtrace.rs:66:9       
   3:        0x104698c54 - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as                                    
core::fmt::Display>::fmt::h616cb314f2809ae5                                                                                   
                               at /rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library/std/src/sys/backtrace.rs:39:26      
   4:        0x1046a9ea0 - core::fmt::rt::Argument::fmt::hbabb1badee5581b4                                                    
                               at /rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library/core/src/fmt/rt.rs:173:76           
   5:        0x1046a9ea0 - core::fmt::write::h18ff235c5756333a                                                                
                               at /rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library/core/src/fmt/mod.rs:1468:25         
   6:        0x10467761c - std::io::default_write_fmt::had3556b08ac88f20                                                      
                               at /rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library/std/src/io/mod.rs:639:11            
   7:        0x10467761c - std::io::Write::write_fmt::h08b80747d0efe8cf                                                       
                               at /rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library/std/src/io/mod.rs:1954:13           
   8:        0x10467d72c - std::sys::backtrace::BacktraceLock::print::h96f00828e06745e0                                       
                               at /rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library/std/src/sys/backtrace.rs:42:9       
   9:        0x104680758 - std::panicking::default_hook::{{closure}}::h662f695cb162c645                                       
                               at /rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library/std/src/panicking.rs:301:27         
  10:        0x10468060c - std::panicking::default_hook::hdc5171bc2654f38e                                                    
                               at /rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library/std/src/panicking.rs:328:9          
  11:        0x104680f50 - std::panicking::panic_with_hook::hc216de099a2fe04e                                                 
                               at /rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library/std/src/panicking.rs:834:13         
  12:        0x104680c10 - std::panicking::panic_handler::{{closure}}::hc0a7f90b1247e042                                      
                               at /rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library/std/src/panicking.rs:700:13         
  13:        0x10467d844 - std::sys::backtrace::__rust_end_short_backtrace::he22d41b92463e575                                 
                               at /rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library/std/src/sys/backtrace.rs:174:18     
  14:        0x10466fcd4 - __rustc[de0091b922c53d7e]::rust_begin_unwind                                                       
                               at /rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library/std/src/panicking.rs:698:5          
  15:        0x1046d070c - core::panicking::panic_nounwind_fmt::runtime::h70d6bddecd3b47d9                                    
                               at /rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library/core/src/panicking.rs:117:22        
  16:        0x1046d070c - core::panicking::panic_nounwind_fmt::he7b3b461c44adf19                                             
                               at /rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library/core/src/intrinsics/mod.rs:2435:9   
  17:        0x1046d0670 - core::panicking::panic_nounwind::h82f92e8e7c9f657c                                                 
                               at /rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library/core/src/panicking.rs:225:5         
  18:        0x1046d0810 - core::panicking::panic_cannot_unwind::h3811ef26462f5a57                                            
                               at /rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library/core/src/panicking.rs:337:5         
  19:        0x1043954a4 -                                                                                                    
winit::platform_impl::macos::app_state::ApplicationDelegate::app_did_finish_launching::hcd3130c85204cec1                      
                               at                                                                                             
/Users/redacted/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/objc2-0.5.2/src/macros/declare_class.rs:981:25        
  20:        0x1879079bc - <unknown>                                                                                          
  21:        0x18799408c - <unknown>                                                                                          
  22:        0x187993fd0 - <unknown>                                                                                          
  23:        0x1878d63d0 - <unknown>                                                                                          
  24:        0x18910b4a4 - <unknown>                                                                                          
  25:        0x18bd485e8 - <unknown>                                                                                          
  26:        0x18bd48380 - <unknown>                                                                                          
  27:        0x18bd469c4 - <unknown>                                                                                          
  28:        0x18bd465d8 - <unknown>                                                                                          
  29:        0x189133fbc - <unknown>                                                                                          
  30:        0x189133db4 - <unknown>                                                                                          
thread caused non-unwinding panic. aborting. 
```

`[186, 243, 32, 189, 189, 183, 212]` 바이트를 EUC-KR로 인코딩하면 `빈 슬롯`인데, UTF8로 강제로 디코딩해서 오류가 발생하고있습니다.

[공식 문서](https://mirusu400.github.io/wipi-wiki/cldc/java-api/java/io/datainput/#%EB%A9%94%EC%84%9C%EB%93%9C-%EC%9A%94%EC%95%BD) 에는 `수정된 UTF-8` 이라고 하는데 이게 그냥 EUC-KR 폴백을 넣은 UTF8이지 않을까 싶습니다..

readUTF 함수 외에는 문자열을 읽는 함수가 없어서, 단순히 Throw Exception으로는 해결이 안될거라 생각하고 일단 폴백 로직을 넣었습니다. 우선은 잘 작동하는걸 확인해서, PR 요청 드려봅니다.


