### PR TITLE
Use inline format args in tracing logs

### DIFF
--- a/java_runtime/src/classes/java/io/buffered_reader.rs
+++ b/java_runtime/src/classes/java/io/buffered_reader.rs
@@ -34,7 +34,7 @@ impl BufferedReader {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, r#in: ClassInstanceRef<Reader>) -> Result<()> {
-        tracing::debug!("java.io.BufferedReader::<init>({:?}, {:?})", &this, &r#in);
+        tracing::debug!("java.io.BufferedReader::<init>({this:?}, {:?})", &r#in);
 
         let _: () = jvm.invoke_special(&this, "java/io/Reader", "<init>", "()V", ()).await?;
 
@@ -48,7 +48,7 @@ impl BufferedReader {
     }
 
     async fn read_line(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<String>> {
-        tracing::debug!("java.io.BufferedReader::readLine({:?})", &this);
+        tracing::debug!("java.io.BufferedReader::readLine({this:?})");
 
         let buf: ClassInstanceRef<Array<JavaChar>> = jvm.get_field(&this, "buf", "[C").await?;
 

--- a/java_runtime/src/classes/java/io/byte_array_input_stream.rs
+++ b/java_runtime/src/classes/java/io/byte_array_input_stream.rs
@@ -67,7 +67,7 @@ impl ByteArrayInputStream {
     }
 
     async fn available(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<i32> {
-        tracing::debug!("java.io.ByteArrayInputStream::available({:?})", &this);
+        tracing::debug!("java.io.ByteArrayInputStream::available({this:?})");
 
         let count: i32 = jvm.get_field(&this, "count", "I").await?;
         let pos: i32 = jvm.get_field(&this, "pos", "I").await?;
@@ -83,7 +83,7 @@ impl ByteArrayInputStream {
         off: i32,
         len: i32,
     ) -> Result<i32> {
-        tracing::debug!("java.io.ByteArrayInputStream::read({:?}, {:?}, {}, {})", &this, &b, off, len);
+        tracing::debug!("java.io.ByteArrayInputStream::read({this:?}, {b:?}, {off}, {len})");
 
         let buf = jvm.get_field(&this, "buf", "[B").await?;
         let buf_length = jvm.array_length(&buf).await?;
@@ -110,7 +110,7 @@ impl ByteArrayInputStream {
     }
 
     async fn read_byte(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>) -> Result<i32> {
-        tracing::debug!("java.io.ByteArrayInputStream::readByte({:?})", &this);
+        tracing::debug!("java.io.ByteArrayInputStream::readByte({this:?})");
 
         let buf = jvm.get_field(&this, "buf", "[B").await?;
         let buf_length = jvm.array_length(&buf).await?;
@@ -128,13 +128,13 @@ impl ByteArrayInputStream {
     }
 
     async fn close(_: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<ByteArrayInputStream>) -> Result<()> {
-        tracing::debug!("java.io.ByteArrayInputStream::close({:?})", &this);
+        tracing::debug!("java.io.ByteArrayInputStream::close({this:?})");
 
         Ok(())
     }
 
     async fn skip(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, n: i64) -> Result<i64> {
-        tracing::debug!("java.io.ByteArrayInputStream::skip({:?}, {:?})", &this, n);
+        tracing::debug!("java.io.ByteArrayInputStream::skip({this:?}, {n:?})");
 
         let buf = jvm.get_field(&this, "buf", "[B").await?;
         let buf_length = jvm.array_length(&buf).await?;
@@ -149,7 +149,7 @@ impl ByteArrayInputStream {
     }
 
     async fn mark(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, readlimit: i32) -> Result<()> {
-        tracing::debug!("java.io.ByteArrayInputStream::mark({:?}, {:?})", &this, readlimit);
+        tracing::debug!("java.io.ByteArrayInputStream::mark({this:?}, {readlimit:?})");
 
         let pos: i32 = jvm.get_field(&this, "pos", "I").await?;
         jvm.put_field(&mut this, "mark", "I", pos).await?;
@@ -158,7 +158,7 @@ impl ByteArrayInputStream {
     }
 
     async fn reset(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.io.ByteArrayInputStream::reset({:?})", &this);
+        tracing::debug!("java.io.ByteArrayInputStream::reset({this:?})");
 
         let mark: i32 = jvm.get_field(&this, "mark", "I").await?;
         jvm.put_field(&mut this, "pos", "I", mark).await?;

--- a/java_runtime/src/classes/java/io/byte_array_output_stream.rs
+++ b/java_runtime/src/classes/java/io/byte_array_output_stream.rs
@@ -32,7 +32,7 @@ impl ByteArrayOutputStream {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.io.ByteArrayOutputStream::<init>({:?})", &this);
+        tracing::debug!("java.io.ByteArrayOutputStream::<init>({this:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/io/ByteArrayOutputStream", "<init>", "(I)V", (1024,))
@@ -42,7 +42,7 @@ impl ByteArrayOutputStream {
     }
 
     async fn init_with_size(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, size: i32) -> Result<()> {
-        tracing::debug!("java.io.ByteArrayOutputStream::<init>({:?}, {:?})", &this, size);
+        tracing::debug!("java.io.ByteArrayOutputStream::<init>({this:?}, {size:?})");
 
         let _: () = jvm.invoke_special(&this, "java/io/OutputStream", "<init>", "()V", ()).await?;
 
@@ -55,7 +55,7 @@ impl ByteArrayOutputStream {
     }
 
     async fn write(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, b: i32) -> Result<()> {
-        tracing::debug!("java.io.ByteArrayOutputStream::write({:?}, {:?})", &this, b);
+        tracing::debug!("java.io.ByteArrayOutputStream::write({this:?}, {b:?})");
 
         let pos: i32 = jvm.get_field(&this, "pos", "I").await?;
         Self::ensure_capacity(jvm, &mut this, (pos + 1) as _).await?;
@@ -69,7 +69,7 @@ impl ByteArrayOutputStream {
     }
 
     async fn to_byte_array(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<Array<i8>>> {
-        tracing::debug!("java.io.ByteArrayOutputStream::to_byte_array({:?})", &this);
+        tracing::debug!("java.io.ByteArrayOutputStream::to_byte_array({this:?})");
 
         let buf: ClassInstanceRef<Array<i8>> = jvm.get_field(&this, "buf", "[B").await?;
         let pos: i32 = jvm.get_field(&this, "pos", "I").await?;
@@ -88,7 +88,7 @@ impl ByteArrayOutputStream {
     }
 
     async fn size(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<i32> {
-        tracing::debug!("java.io.ByteArrayOutputStream::size({:?})", &this);
+        tracing::debug!("java.io.ByteArrayOutputStream::size({this:?})");
 
         let pos: i32 = jvm.get_field(&this, "pos", "I").await?;
 
@@ -96,7 +96,7 @@ impl ByteArrayOutputStream {
     }
 
     async fn reset(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.io.ByteArrayOutputStream::reset({:?})", &this);
+        tracing::debug!("java.io.ByteArrayOutputStream::reset({this:?})");
 
         jvm.put_field(&mut this, "pos", "I", 0).await?;
 

--- a/java_runtime/src/classes/java/io/data_input_stream.rs
+++ b/java_runtime/src/classes/java/io/data_input_stream.rs
@@ -39,7 +39,7 @@ impl DataInputStream {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, r#in: ClassInstanceRef<InputStream>) -> Result<()> {
-        tracing::debug!("java.io.DataInputStream::<init>({:?}, {:?})", &this, &r#in);
+        tracing::debug!("java.io.DataInputStream::<init>({this:?}, {:?})", &r#in);
 
         let _: () = jvm
             .invoke_special(&this, "java/io/FilterInputStream", "<init>", "(Ljava/io/InputStream;)V", (r#in,))
@@ -49,7 +49,7 @@ impl DataInputStream {
     }
 
     async fn read_byte(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<i8> {
-        tracing::debug!("java.io.DataInputStream::readByte({:?})", &this);
+        tracing::debug!("java.io.DataInputStream::readByte({this:?})");
 
         let r#in = jvm.get_field(&this, "in", "Ljava/io/InputStream;").await?;
         let result: i32 = jvm.invoke_virtual(&r#in, "read", "()I", ()).await?;
@@ -58,7 +58,7 @@ impl DataInputStream {
     }
 
     async fn read_boolean(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<bool> {
-        tracing::debug!("java.io.DataInputStream::readBoolean({:?})", &this);
+        tracing::debug!("java.io.DataInputStream::readBoolean({this:?})");
 
         let r#in = jvm.get_field(&this, "in", "Ljava/io/InputStream;").await?;
         let byte: i32 = jvm.invoke_virtual(&r#in, "read", "()I", ()).await?;
@@ -67,7 +67,7 @@ impl DataInputStream {
     }
 
     async fn read_char(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<JavaChar> {
-        tracing::debug!("java.io.DataInputStream::readChar({:?})", &this);
+        tracing::debug!("java.io.DataInputStream::readChar({this:?})");
 
         let r#in = jvm.get_field(&this, "in", "Ljava/io/InputStream;").await?;
 
@@ -78,7 +78,7 @@ impl DataInputStream {
     }
 
     async fn read_short(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<i16> {
-        tracing::debug!("java.io.DataInputStream::readShort({:?})", &this);
+        tracing::debug!("java.io.DataInputStream::readShort({this:?})");
 
         let r#in = jvm.get_field(&this, "in", "Ljava/io/InputStream;").await?;
 
@@ -89,7 +89,7 @@ impl DataInputStream {
     }
 
     async fn read_unsigned_short(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<i32> {
-        tracing::debug!("java.io.DataInputStream::readUnsignedShort({:?})", &this);
+        tracing::debug!("java.io.DataInputStream::readUnsignedShort({this:?})");
 
         let r#in = jvm.get_field(&this, "in", "Ljava/io/InputStream;").await?;
 
@@ -100,7 +100,7 @@ impl DataInputStream {
     }
 
     async fn read_int(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<i32> {
-        tracing::debug!("java.io.DataInputStream::readInt({:?})", &this);
+        tracing::debug!("java.io.DataInputStream::readInt({this:?})");
 
         let r#in = jvm.get_field(&this, "in", "Ljava/io/InputStream;").await?;
 
@@ -113,7 +113,7 @@ impl DataInputStream {
     }
 
     async fn read_long(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<i64> {
-        tracing::debug!("java.io.DataInputStream::readLong({:?})", &this);
+        tracing::debug!("java.io.DataInputStream::readLong({this:?})");
 
         let r#in = jvm.get_field(&this, "in", "Ljava/io/InputStream;").await?;
 
@@ -137,7 +137,7 @@ impl DataInputStream {
     }
 
     async fn read_float(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<f32> {
-        tracing::debug!("java.io.DataInputStream::readFloat({:?})", &this);
+        tracing::debug!("java.io.DataInputStream::readFloat({this:?})");
 
         let r#in = jvm.get_field(&this, "in", "Ljava/io/InputStream;").await?;
 
@@ -150,7 +150,7 @@ impl DataInputStream {
     }
 
     async fn read_double(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<f64> {
-        tracing::debug!("java.io.DataInputStream::readDouble({:?})", &this);
+        tracing::debug!("java.io.DataInputStream::readDouble({this:?})");
 
         let r#in = jvm.get_field(&this, "in", "Ljava/io/InputStream;").await?;
 
@@ -176,7 +176,7 @@ impl DataInputStream {
     }
 
     async fn read_utf(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<String>> {
-        tracing::debug!("java.io.DataInputStream::readUTF({:?})", &this);
+        tracing::debug!("java.io.DataInputStream::readUTF({this:?})");
 
         let length: i32 = jvm.invoke_virtual(&this, "readUnsignedShort", "()I", ()).await?;
         let java_array = jvm.instantiate_array("B", length as _).await?;
@@ -199,7 +199,7 @@ impl DataInputStream {
     }
 
     async fn read_fully(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, b: ClassInstanceRef<Array<i8>>) -> Result<()> {
-        tracing::debug!("java.io.DataInputStream::readFully({:?}, {:?})", &this, &b);
+        tracing::debug!("java.io.DataInputStream::readFully({this:?}, {b:?})");
 
         let length = jvm.array_length(&b).await?;
 
@@ -216,7 +216,7 @@ impl DataInputStream {
         off: i32,
         len: i32,
     ) -> Result<()> {
-        tracing::debug!("java.io.DataInputStream::readFully({:?}, {:?}, {}, {})", &this, &b, off, len);
+        tracing::debug!("java.io.DataInputStream::readFully({this:?}, {b:?}, {off}, {len})");
 
         let mut read = 0;
         while read < len {
@@ -231,7 +231,7 @@ impl DataInputStream {
     }
 
     async fn skip_bytes(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, n: i32) -> Result<i32> {
-        tracing::debug!("java.io.DataInputStream::skipBytes({:?}, {:?})", &this, n);
+        tracing::debug!("java.io.DataInputStream::skipBytes({this:?}, {n:?})");
 
         let r#in = jvm.get_field(&this, "in", "Ljava/io/InputStream;").await?;
         let skipped: i64 = jvm.invoke_virtual(&r#in, "skip", "(J)J", (n as i64,)).await?;

--- a/java_runtime/src/classes/java/io/data_output_stream.rs
+++ b/java_runtime/src/classes/java/io/data_output_stream.rs
@@ -71,7 +71,7 @@ impl DataOutputStream {
     }
 
     async fn write_short(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, s: i32) -> Result<()> {
-        tracing::debug!("java.io.DataOutputStream::writeShort({:?}, {:?})", &this, s);
+        tracing::debug!("java.io.DataOutputStream::writeShort({this:?}, {s:?})");
 
         let bytes = (s as i16).to_be_bytes();
         let mut byte_array = jvm.instantiate_array("B", bytes.len() as _).await?;
@@ -84,7 +84,7 @@ impl DataOutputStream {
     }
 
     async fn write_int(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, i: i32) -> Result<()> {
-        tracing::debug!("java.io.DataOutputStream::writeInt({:?}, {:?})", &this, i);
+        tracing::debug!("java.io.DataOutputStream::writeInt({this:?}, {i:?})");
 
         let bytes = i.to_be_bytes();
         let mut byte_array = jvm.instantiate_array("B", bytes.len() as _).await?;
@@ -97,7 +97,7 @@ impl DataOutputStream {
     }
 
     async fn write_long(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, l: i64) -> Result<()> {
-        tracing::debug!("java.io.DataOutputStream::writeLong({:?}, {:?})", &this, l);
+        tracing::debug!("java.io.DataOutputStream::writeLong({this:?}, {l:?})");
 
         let bytes = l.to_be_bytes();
         let mut byte_array = jvm.instantiate_array("B", bytes.len() as _).await?;
@@ -110,7 +110,7 @@ impl DataOutputStream {
     }
 
     async fn write_chars(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, s: ClassInstanceRef<JavaChar>) -> Result<()> {
-        tracing::debug!("java.io.DataOutputStream::writeChars({:?}, {:?})", &this, &s);
+        tracing::debug!("java.io.DataOutputStream::writeChars({this:?}, {s:?})");
 
         let bytes: ClassInstanceRef<Array<i8>> = jvm.invoke_virtual(&s, "getBytes", "()[B", ()).await?;
 
@@ -121,7 +121,7 @@ impl DataOutputStream {
     }
 
     async fn write_utf(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, s: ClassInstanceRef<JavaChar>) -> Result<()> {
-        tracing::debug!("java.io.DataOutputStream::writeUTF({:?}, {:?})", &this, &s);
+        tracing::debug!("java.io.DataOutputStream::writeUTF({this:?}, {s:?})");
 
         // TODO handle modified utf-8
         let bytes: ClassInstanceRef<Array<i8>> = jvm.invoke_virtual(&s, "getBytes", "()[B", ()).await?;
@@ -136,7 +136,7 @@ impl DataOutputStream {
     }
 
     async fn close(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.io.DataInputStream::close({:?})", &this);
+        tracing::debug!("java.io.DataInputStream::close({this:?})");
 
         let out = jvm.get_field(&this, "out", "Ljava/io/OutputStream;").await?;
         let _: () = jvm.invoke_virtual(&out, "close", "()V", []).await?;
@@ -145,7 +145,7 @@ impl DataOutputStream {
     }
 
     async fn flush(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.io.DataInputStream::flush({:?})", &this);
+        tracing::debug!("java.io.DataInputStream::flush({this:?})");
 
         let out = jvm.get_field(&this, "out", "Ljava/io/OutputStream;").await?;
         let _: () = jvm.invoke_virtual(&out, "flush", "()V", []).await?;

--- a/java_runtime/src/classes/java/io/data_output_stream.rs
+++ b/java_runtime/src/classes/java/io/data_output_stream.rs
@@ -136,7 +136,7 @@ impl DataOutputStream {
     }
 
     async fn close(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.io.DataInputStream::close({this:?})");
+        tracing::debug!("java.io.DataOutputStream::close({this:?})");
 
         let out = jvm.get_field(&this, "out", "Ljava/io/OutputStream;").await?;
         let _: () = jvm.invoke_virtual(&out, "close", "()V", []).await?;
@@ -145,7 +145,7 @@ impl DataOutputStream {
     }
 
     async fn flush(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.io.DataInputStream::flush({this:?})");
+        tracing::debug!("java.io.DataOutputStream::flush({this:?})");
 
         let out = jvm.get_field(&this, "out", "Ljava/io/OutputStream;").await?;
         let _: () = jvm.invoke_virtual(&out, "flush", "()V", []).await?;

--- a/java_runtime/src/classes/java/io/eof_exception.rs
+++ b/java_runtime/src/classes/java/io/eof_exception.rs
@@ -24,7 +24,7 @@ impl EOFException {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.io.EOFException::<init>({:?})", &this);
+        tracing::debug!("java.io.EOFException::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/io/IOException", "<init>", "()V", ()).await?;
 
@@ -32,7 +32,7 @@ impl EOFException {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.io.EOFException::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.io.EOFException::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/io/IOException", "<init>", "(Ljava/lang/String;)V", (message,))

--- a/java_runtime/src/classes/java/io/file.rs
+++ b/java_runtime/src/classes/java/io/file.rs
@@ -29,7 +29,7 @@ impl File {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, pathname: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.io.File::<init>({:?}, {:?})", &this, &pathname);
+        tracing::debug!("java.io.File::<init>({this:?}, {pathname:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -39,13 +39,13 @@ impl File {
     }
 
     async fn get_path(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<String>> {
-        tracing::debug!("java.io.File::getPath({:?})", &this);
+        tracing::debug!("java.io.File::getPath({this:?})");
 
         jvm.get_field(&this, "path", "Ljava/lang/String;").await
     }
 
     async fn exists(jvm: &Jvm, context: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<bool> {
-        tracing::debug!("java.io.File::exists({:?})", &this);
+        tracing::debug!("java.io.File::exists({this:?})");
 
         let path = jvm.invoke_virtual(&this, "getPath", "()Ljava/lang/String;", ()).await?;
         let path = JavaLangString::to_rust_string(jvm, &path).await?;
@@ -54,7 +54,7 @@ impl File {
     }
 
     async fn is_directory(jvm: &Jvm, context: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<bool> {
-        tracing::debug!("java.io.File::isDirectory({:?})", &this);
+        tracing::debug!("java.io.File::isDirectory({this:?})");
 
         let path = jvm.invoke_virtual(&this, "getPath", "()Ljava/lang/String;", ()).await?;
         let path = JavaLangString::to_rust_string(jvm, &path).await?;
@@ -68,7 +68,7 @@ impl File {
     }
 
     async fn is_file(jvm: &Jvm, context: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<bool> {
-        tracing::debug!("java.io.File::isFile({:?})", &this);
+        tracing::debug!("java.io.File::isFile({this:?})");
 
         let path = jvm.invoke_virtual(&this, "getPath", "()Ljava/lang/String;", ()).await?;
         let path = JavaLangString::to_rust_string(jvm, &path).await?;
@@ -82,7 +82,7 @@ impl File {
     }
 
     async fn delete(jvm: &Jvm, context: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<bool> {
-        tracing::debug!("java.io.File::delete({:?})", &this);
+        tracing::debug!("java.io.File::delete({this:?})");
 
         let path = jvm.invoke_virtual(&this, "getPath", "()Ljava/lang/String;", ()).await?;
         let path = JavaLangString::to_rust_string(jvm, &path).await?;
@@ -91,7 +91,7 @@ impl File {
     }
 
     async fn length(jvm: &Jvm, context: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<i64> {
-        tracing::debug!("java.io.File::length({:?})", &this);
+        tracing::debug!("java.io.File::length({this:?})");
 
         let path = jvm.invoke_virtual(&this, "getPath", "()Ljava/lang/String;", ()).await?;
         let path = JavaLangString::to_rust_string(jvm, &path).await?;

--- a/java_runtime/src/classes/java/io/file_descriptor.rs
+++ b/java_runtime/src/classes/java/io/file_descriptor.rs
@@ -63,7 +63,7 @@ impl FileDescriptor {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.io.FileDescriptor::<init>({:?})", &this);
+        tracing::debug!("java.io.FileDescriptor::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 

--- a/java_runtime/src/classes/java/io/file_input_stream.rs
+++ b/java_runtime/src/classes/java/io/file_input_stream.rs
@@ -38,7 +38,7 @@ impl FileInputStream {
     }
 
     async fn init(jvm: &Jvm, context: &mut RuntimeContext, this: ClassInstanceRef<Self>, file: ClassInstanceRef<File>) -> Result<()> {
-        tracing::debug!("java.io.FileInputStream::<init>({:?}, {:?})", &this, &file);
+        tracing::debug!("java.io.FileInputStream::<init>({this:?}, {file:?})");
 
         let path = jvm.invoke_virtual(&file, "getPath", "()Ljava/lang/String;", ()).await?;
         let path = JavaLangString::to_rust_string(jvm, &path).await?;
@@ -63,7 +63,7 @@ impl FileInputStream {
         mut this: ClassInstanceRef<Self>,
         fd: ClassInstanceRef<FileDescriptor>,
     ) -> Result<()> {
-        tracing::debug!("java.io.FileInputStream::<init>({:?}, {:?})", &this, &fd);
+        tracing::debug!("java.io.FileInputStream::<init>({this:?}, {fd:?})");
 
         let _: () = jvm.invoke_special(&this, "java/io/InputStream", "<init>", "()V", ()).await?;
 
@@ -73,7 +73,7 @@ impl FileInputStream {
     }
 
     async fn available(jvm: &Jvm, context: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<i32> {
-        tracing::debug!("java.io.FileInputStream::available({:?})", &this);
+        tracing::debug!("java.io.FileInputStream::available({this:?})");
 
         let fd = jvm.get_field(&this, "fd", "Ljava/io/FileDescriptor;").await?;
         let rust_file = FileDescriptor::file(jvm, context, fd).await?;
@@ -112,7 +112,7 @@ impl FileInputStream {
     }
 
     async fn read_byte(jvm: &Jvm, context: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<i32> {
-        tracing::debug!("java.io.FileInputStream::read({:?})", &this);
+        tracing::debug!("java.io.FileInputStream::read({this:?})");
 
         let fd = jvm.get_field(&this, "fd", "Ljava/io/FileDescriptor;").await?;
         let mut rust_file = FileDescriptor::file(jvm, context, fd).await?;
@@ -127,7 +127,7 @@ impl FileInputStream {
     }
 
     async fn close(jvm: &Jvm, context: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.io.FileInputStream::close({:?})", &this);
+        tracing::debug!("java.io.FileInputStream::close({this:?})");
 
         let fd = jvm.get_field(&this, "fd", "Ljava/io/FileDescriptor;").await?;
         FileDescriptor::close(jvm, context, fd).await?;

--- a/java_runtime/src/classes/java/io/file_not_found_exception.rs
+++ b/java_runtime/src/classes/java/io/file_not_found_exception.rs
@@ -24,7 +24,7 @@ impl FileNotFoundException {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.io.FileNotFoundException::<init>({:?})", &this);
+        tracing::debug!("java.io.FileNotFoundException::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/io/IOException", "<init>", "()V", ()).await?;
 
@@ -32,7 +32,7 @@ impl FileNotFoundException {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.io.FileNotFoundException::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.io.FileNotFoundException::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/io/IOException", "<init>", "(Ljava/lang/String;)V", (message,))

--- a/java_runtime/src/classes/java/io/file_output_stream.rs
+++ b/java_runtime/src/classes/java/io/file_output_stream.rs
@@ -37,7 +37,7 @@ impl FileOutputStream {
     }
 
     async fn init(jvm: &Jvm, context: &mut RuntimeContext, this: ClassInstanceRef<Self>, file: ClassInstanceRef<File>) -> Result<()> {
-        tracing::debug!("java.io.FileOutputStream::<init>({:?}, {:?})", &this, &file);
+        tracing::debug!("java.io.FileOutputStream::<init>({this:?}, {file:?})");
 
         let path = jvm.invoke_virtual(&file, "getPath", "()Ljava/lang/String;", ()).await?;
         let path = JavaLangString::to_rust_string(jvm, &path).await?;
@@ -58,7 +58,7 @@ impl FileOutputStream {
         mut this: ClassInstanceRef<Self>,
         file_descriptor: ClassInstanceRef<File>,
     ) -> Result<()> {
-        tracing::debug!("java.io.FileOutputStream::<init>({:?}, {:?})", &this, &file_descriptor);
+        tracing::debug!("java.io.FileOutputStream::<init>({this:?}, {file_descriptor:?})");
 
         let _: () = jvm.invoke_special(&this, "java/io/OutputStream", "<init>", "()V", ()).await?;
 
@@ -75,13 +75,7 @@ impl FileOutputStream {
         offset: i32,
         length: i32,
     ) -> Result<()> {
-        tracing::debug!(
-            "java.io.FileOutputStream::write({:?}, {:?}, {:?}, {:?})",
-            &this,
-            &buffer,
-            &offset,
-            &length
-        );
+        tracing::debug!("java.io.FileOutputStream::write({this:?}, {buffer:?}, {offset:?}, {length:?})");
 
         let fd = jvm.get_field(&this, "fd", "Ljava/io/FileDescriptor;").await?;
         let mut file = FileDescriptor::file(jvm, context, fd).await?;
@@ -95,7 +89,7 @@ impl FileOutputStream {
     }
 
     async fn write(jvm: &Jvm, context: &mut RuntimeContext, this: ClassInstanceRef<Self>, byte: i32) -> Result<()> {
-        tracing::debug!("java.io.FileOutputStream::write({:?}, {:?})", &this, &byte);
+        tracing::debug!("java.io.FileOutputStream::write({this:?}, {byte:?})");
 
         let fd = jvm.get_field(&this, "fd", "Ljava/io/FileDescriptor;").await?;
         let mut file = FileDescriptor::file(jvm, context, fd).await?;
@@ -106,7 +100,7 @@ impl FileOutputStream {
     }
 
     async fn close(jvm: &Jvm, context: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.io.FileOutputStream::close({:?})", &this);
+        tracing::debug!("java.io.FileOutputStream::close({this:?})");
 
         let fd = jvm.get_field(&this, "fd", "Ljava/io/FileDescriptor;").await?;
         FileDescriptor::close(jvm, context, fd).await?;

--- a/java_runtime/src/classes/java/io/filter_input_stream.rs
+++ b/java_runtime/src/classes/java/io/filter_input_stream.rs
@@ -30,7 +30,7 @@ impl FilterInputStream {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, r#in: ClassInstanceRef<InputStream>) -> Result<()> {
-        tracing::debug!("java.io.FilterInputStream::<init>({:?}, {:?})", &this, &r#in);
+        tracing::debug!("java.io.FilterInputStream::<init>({this:?}, {:?})", &r#in);
 
         let _: () = jvm.invoke_special(&this, "java/io/InputStream", "<init>", "()V", ()).await?;
 
@@ -40,7 +40,7 @@ impl FilterInputStream {
     }
 
     async fn available(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<i32> {
-        tracing::debug!("java.io.FilterInputStream::available({:?})", &this);
+        tracing::debug!("java.io.FilterInputStream::available({this:?})");
 
         let r#in = jvm.get_field(&this, "in", "Ljava/io/InputStream;").await?;
         let available: i32 = jvm.invoke_virtual(&r#in, "available", "()I", ()).await?;
@@ -49,7 +49,7 @@ impl FilterInputStream {
     }
 
     async fn close(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.io.FilterInputStream::close({:?})", &this);
+        tracing::debug!("java.io.FilterInputStream::close({this:?})");
 
         let r#in = jvm.get_field(&this, "in", "Ljava/io/InputStream;").await?;
         let _: () = jvm.invoke_virtual(&r#in, "close", "()V", ()).await?;
@@ -58,7 +58,7 @@ impl FilterInputStream {
     }
 
     async fn reset(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.io.FilterInputStream::reset({:?})", &this);
+        tracing::debug!("java.io.FilterInputStream::reset({this:?})");
 
         let r#in = jvm.get_field(&this, "in", "Ljava/io/InputStream;").await?;
         let _: () = jvm.invoke_virtual(&r#in, "reset", "()V", ()).await?;
@@ -67,7 +67,7 @@ impl FilterInputStream {
     }
 
     async fn read(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, b: ClassInstanceRef<Array<i8>>) -> Result<i32> {
-        tracing::debug!("java.io.FilterInputStream::read({:?}, {:?})", &this, &b);
+        tracing::debug!("java.io.FilterInputStream::read({this:?}, {b:?})");
 
         let r#in = jvm.get_field(&this, "in", "Ljava/io/InputStream;").await?;
         let result: i32 = jvm.invoke_virtual(&r#in, "read", "([B)I", (b,)).await?;
@@ -83,7 +83,7 @@ impl FilterInputStream {
         off: i32,
         len: i32,
     ) -> Result<i32> {
-        tracing::debug!("java.io.FilterInputStream::read({:?}, {:?}, {}, {})", &this, &b, off, len);
+        tracing::debug!("java.io.FilterInputStream::read({this:?}, {b:?}, {off}, {len})");
 
         let r#in = jvm.get_field(&this, "in", "Ljava/io/InputStream;").await?;
         let result: i32 = jvm.invoke_virtual(&r#in, "read", "([BII)I", (b, off, len)).await?;
@@ -92,7 +92,7 @@ impl FilterInputStream {
     }
 
     async fn read_byte_int(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<i32> {
-        tracing::debug!("java.io.FilterInputStream::read({:?})", &this);
+        tracing::debug!("java.io.FilterInputStream::read({this:?})");
 
         let r#in = jvm.get_field(&this, "in", "Ljava/io/InputStream;").await?;
         let result: i32 = jvm.invoke_virtual(&r#in, "read", "()I", ()).await?;

--- a/java_runtime/src/classes/java/io/filter_output_stream.rs
+++ b/java_runtime/src/classes/java/io/filter_output_stream.rs
@@ -26,7 +26,7 @@ impl FilterOutputStream {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, out: ClassInstanceRef<OutputStream>) -> Result<()> {
-        tracing::debug!("java.io.FilterOutputStream::<init>({:?}, {:?})", &this, &out);
+        tracing::debug!("java.io.FilterOutputStream::<init>({this:?}, {out:?})");
 
         let _: () = jvm.invoke_special(&this, "java/io/OutputStream", "<init>", "()V", ()).await?;
 
@@ -43,13 +43,7 @@ impl FilterOutputStream {
         offset: i32,
         length: i32,
     ) -> Result<()> {
-        tracing::debug!(
-            " java.io.FilterOutputStream::write({:?}, {:?}, {:?}, {:?})",
-            &this,
-            &bytes,
-            &offset,
-            &length
-        );
+        tracing::debug!(" java.io.FilterOutputStream::write({this:?}, {bytes:?}, {offset:?}, {length:?})");
 
         let out = jvm.get_field(&this, "out", "Ljava/io/OutputStream;").await?;
         let _: () = jvm.invoke_virtual(&out, "write", "([BII)V", (bytes, offset, length)).await?;
@@ -58,7 +52,7 @@ impl FilterOutputStream {
     }
 
     async fn write(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, byte: i32) -> Result<()> {
-        tracing::debug!("java.io.FilterOutputStream::write({:?}, {:?})", &this, &byte);
+        tracing::debug!("java.io.FilterOutputStream::write({this:?}, {byte:?})");
 
         let out = jvm.get_field(&this, "out", "Ljava/io/OutputStream;").await?;
         let _: () = jvm.invoke_virtual(&out, "write", "(I)V", (byte,)).await?;

--- a/java_runtime/src/classes/java/io/input_stream.rs
+++ b/java_runtime/src/classes/java/io/input_stream.rs
@@ -32,7 +32,7 @@ impl InputStream {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.io.InputStream::<init>({:?})", &this);
+        tracing::debug!("java.io.InputStream::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -40,7 +40,7 @@ impl InputStream {
     }
 
     async fn read(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, b: ClassInstanceRef<Array<i8>>) -> Result<i32> {
-        tracing::debug!("java.io.InputStream::read({:?}, {:?})", &this, &b);
+        tracing::debug!("java.io.InputStream::read({this:?}, {b:?})");
 
         let array_length = jvm.array_length(&b).await? as i32;
 
@@ -48,7 +48,7 @@ impl InputStream {
     }
 
     async fn skip(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, n: i64) -> Result<i64> {
-        tracing::debug!("java.io.InputStream::skip({:?}, {:?})", &this, n);
+        tracing::debug!("java.io.InputStream::skip({this:?}, {n:?})");
 
         if n <= 0 {
             return Ok(0);
@@ -72,13 +72,13 @@ impl InputStream {
     }
 
     async fn mark(_jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, readlimit: i32) -> Result<()> {
-        tracing::debug!("java.io.InputStream::mark({:?}, {:?})", &this, readlimit);
+        tracing::debug!("java.io.InputStream::mark({this:?}, {readlimit:?})");
 
         Ok(())
     }
 
     async fn reset(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.io.InputStream::reset({:?})", &this);
+        tracing::debug!("java.io.InputStream::reset({this:?})");
 
         Err(jvm.exception("java/io/IOException", "reset not supported").await)
     }

--- a/java_runtime/src/classes/java/io/input_stream_reader.rs
+++ b/java_runtime/src/classes/java/io/input_stream_reader.rs
@@ -42,7 +42,7 @@ impl InputStreamReader {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, r#in: ClassInstanceRef<InputStream>) -> Result<()> {
-        tracing::debug!("java.io.InputStreamReader::<init>({:?}, {:?})", &this, &r#in);
+        tracing::debug!("java.io.InputStreamReader::<init>({this:?}, {:?})", &r#in);
 
         let _: () = jvm.invoke_special(&this, "java/io/Reader", "<init>", "()V", ()).await?;
 
@@ -71,7 +71,7 @@ impl InputStreamReader {
         offset: i32,
         length: i32,
     ) -> Result<i32> {
-        tracing::debug!("java.io.InputStreamReader::read({:?}, {:?}, {:?}, {:?})", &this, &buf, &offset, &length);
+        tracing::debug!("java.io.InputStreamReader::read({this:?}, {buf:?}, {offset:?}, {length:?})");
 
         let write_buf_size: i32 = jvm.get_field(&this, "writeBufSize", "I").await?;
 
@@ -170,7 +170,7 @@ impl InputStreamReader {
     }
 
     async fn close(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.io.InputStreamReader::close({:?})", &this);
+        tracing::debug!("java.io.InputStreamReader::close({this:?})");
 
         let r#in = jvm.get_field(&this, "in", "Ljava/io/InputStream;").await?;
         let _: () = jvm.invoke_virtual(&r#in, "close", "()V", ()).await?;

--- a/java_runtime/src/classes/java/io/io_exception.rs
+++ b/java_runtime/src/classes/java/io/io_exception.rs
@@ -24,7 +24,7 @@ impl IOException {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.io.IOException::<init>({:?})", &this);
+        tracing::debug!("java.io.IOException::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Exception", "<init>", "()V", ()).await?;
 
@@ -32,7 +32,7 @@ impl IOException {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.io.IOException::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.io.IOException::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/Exception", "<init>", "(Ljava/lang/String;)V", (message,))

--- a/java_runtime/src/classes/java/io/output_stream.rs
+++ b/java_runtime/src/classes/java/io/output_stream.rs
@@ -29,7 +29,7 @@ impl OutputStream {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.io.OutputStream::<init>({:?})", &this);
+        tracing::debug!("java.io.OutputStream::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -37,7 +37,7 @@ impl OutputStream {
     }
 
     async fn write_bytes(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, buffer: ClassInstanceRef<Array<i8>>) -> Result<()> {
-        tracing::debug!("java.io.OutputStream::write({:?}, {:?})", &this, &buffer);
+        tracing::debug!("java.io.OutputStream::write({this:?}, {buffer:?})");
 
         let length = jvm.array_length(&buffer).await?;
 
@@ -54,7 +54,7 @@ impl OutputStream {
         offset: i32,
         length: i32,
     ) -> Result<()> {
-        tracing::debug!("java.io.OutputStream::write({:?}, {:?}, {:?}, {:?})", &this, &buffer, &offset, &length);
+        tracing::debug!("java.io.OutputStream::write({this:?}, {buffer:?}, {offset:?}, {length:?})");
 
         let mut bytes = vec![0; length as usize];
         jvm.array_raw_buffer(&buffer).await?.read(offset as _, &mut bytes)?;
@@ -66,13 +66,13 @@ impl OutputStream {
     }
 
     async fn flush(_jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.io.OutputStream::flush({:?})", &this);
+        tracing::debug!("java.io.OutputStream::flush({this:?})");
 
         Ok(())
     }
 
     async fn close(_jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.io.OutputStream::close({:?})", &this);
+        tracing::debug!("java.io.OutputStream::close({this:?})");
 
         Ok(())
     }

--- a/java_runtime/src/classes/java/io/print_stream.rs
+++ b/java_runtime/src/classes/java/io/print_stream.rs
@@ -38,7 +38,7 @@ impl PrintStream {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, out: ClassInstanceRef<OutputStream>) -> Result<()> {
-        tracing::debug!("java.io.PrintStream::<init>({:?}, {:?})", &this, &out);
+        tracing::debug!("java.io.PrintStream::<init>({this:?}, {out:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/io/FilterOutputStream", "<init>", "(Ljava/io/OutputStream;)V", (out,))
@@ -48,7 +48,7 @@ impl PrintStream {
     }
 
     async fn println_object(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, obj: ClassInstanceRef<Object>) -> Result<()> {
-        tracing::debug!("java.io.PrintStream::println({:?}, {:?})", &this, &obj);
+        tracing::debug!("java.io.PrintStream::println({this:?}, {obj:?})");
 
         let result = if obj.is_null() {
             "null\n".into()
@@ -69,7 +69,7 @@ impl PrintStream {
     }
 
     async fn println_string(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, str: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.io.PrintStream::println({:?}, {:?})", &this, &str);
+        tracing::debug!("java.io.PrintStream::println({this:?}, {str:?})");
 
         let result = if str.is_null() {
             "null\n".into()
@@ -88,7 +88,7 @@ impl PrintStream {
     }
 
     async fn println_int(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, int: i32) -> Result<()> {
-        tracing::debug!("java.io.PrintStream::println({:?}, {:?})", &this, &int);
+        tracing::debug!("java.io.PrintStream::println({this:?}, {int:?})");
 
         let java_string = JavaLangString::from_rust_string(jvm, &int.to_string()).await?;
 
@@ -98,7 +98,7 @@ impl PrintStream {
     }
 
     async fn println_long(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, long: i64) -> Result<()> {
-        tracing::debug!("java.io.PrintStream::println({:?}, {:?})", &this, &long);
+        tracing::debug!("java.io.PrintStream::println({this:?}, {long:?})");
 
         let java_string = JavaLangString::from_rust_string(jvm, &long.to_string()).await?;
 
@@ -108,7 +108,7 @@ impl PrintStream {
     }
 
     async fn println_char(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, char: JavaChar) -> Result<()> {
-        tracing::debug!("java.io.PrintStream::println({:?}, {:?})", &this, &char);
+        tracing::debug!("java.io.PrintStream::println({this:?}, {char:?})");
 
         let char = char::from_u32(char as _).unwrap();
 
@@ -120,7 +120,7 @@ impl PrintStream {
     }
 
     async fn println_byte(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, byte: i8) -> Result<()> {
-        tracing::debug!("java.io.PrintStream::println({:?}, {:?})", &this, &byte);
+        tracing::debug!("java.io.PrintStream::println({this:?}, {byte:?})");
 
         let java_string = JavaLangString::from_rust_string(jvm, &byte.to_string()).await?;
 
@@ -130,7 +130,7 @@ impl PrintStream {
     }
 
     async fn println_short(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, short: i16) -> Result<()> {
-        tracing::debug!("java.io.PrintStream::println({:?}, {:?})", &this, &short);
+        tracing::debug!("java.io.PrintStream::println({this:?}, {short:?})");
 
         let java_string = JavaLangString::from_rust_string(jvm, &short.to_string()).await?;
 
@@ -140,7 +140,7 @@ impl PrintStream {
     }
 
     async fn println_bool(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, bool: bool) -> Result<()> {
-        tracing::debug!("java.io.PrintStream::println({:?}, {:?})", &this, &bool);
+        tracing::debug!("java.io.PrintStream::println({this:?}, {bool:?})");
 
         let java_string = JavaLangString::from_rust_string(jvm, &bool.to_string()).await?;
 
@@ -150,7 +150,7 @@ impl PrintStream {
     }
 
     async fn println_double(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, double: f64) -> Result<()> {
-        tracing::debug!("java.io.PrintStream::println({:?}, {:?})", &this, &double);
+        tracing::debug!("java.io.PrintStream::println({this:?}, {double:?})");
 
         let string = format!("{double:.1}");
 

--- a/java_runtime/src/classes/java/io/print_writer.rs
+++ b/java_runtime/src/classes/java/io/print_writer.rs
@@ -28,7 +28,7 @@ impl PrintWriter {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, out: ClassInstanceRef<Writer>) -> Result<()> {
-        tracing::debug!("java.io.PrintWriter::<init>({:?})", &this);
+        tracing::debug!("java.io.PrintWriter::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/io/Writer", "<init>", "()V", ()).await?;
 
@@ -45,7 +45,7 @@ impl PrintWriter {
         off: i32,
         len: i32,
     ) -> Result<i32> {
-        tracing::debug!("java.io.PrintWriter::write({:?}, {:?}, {:?}, {:?})", &this, &chars, &off, &len);
+        tracing::debug!("java.io.PrintWriter::write({this:?}, {chars:?}, {off:?}, {len:?})");
 
         let out = jvm.get_field(&this, "out", "Ljava/io/Writer;").await?;
 
@@ -55,7 +55,7 @@ impl PrintWriter {
     }
 
     async fn println(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, string: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.io.PrintWriter::println({:?}, {:?})", &this, &string);
+        tracing::debug!("java.io.PrintWriter::println({this:?}, {string:?})");
 
         let string = format!("{}\n", JavaLangString::to_rust_string(jvm, &string).await?);
         let string = JavaLangString::from_rust_string(jvm, &string).await?;

--- a/java_runtime/src/classes/java/io/random_access_file.rs
+++ b/java_runtime/src/classes/java/io/random_access_file.rs
@@ -48,7 +48,7 @@ impl RandomAccessFile {
         name: ClassInstanceRef<String>,
         mode: ClassInstanceRef<String>,
     ) -> Result<()> {
-        tracing::debug!("java.io.RandomAccessFile::<init>({:?}, {:?}, {:?})", &this, &name, &mode);
+        tracing::debug!("java.io.RandomAccessFile::<init>({this:?}, {name:?}, {mode:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -74,7 +74,7 @@ impl RandomAccessFile {
         file: ClassInstanceRef<File>,
         mode: ClassInstanceRef<String>,
     ) -> Result<()> {
-        tracing::debug!("java.io.RandomAccessFile::<init>({:?}, {:?}, {:?})", &this, &file, &mode);
+        tracing::debug!("java.io.RandomAccessFile::<init>({this:?}, {file:?}, {mode:?})");
 
         let name: ClassInstanceRef<String> = jvm.invoke_virtual(&file, "getPath", "()Ljava/lang/String;", ()).await?;
 
@@ -92,7 +92,7 @@ impl RandomAccessFile {
     }
 
     async fn read(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, buf: ClassInstanceRef<Array<i8>>) -> Result<i32> {
-        tracing::debug!("java.io.RandomAccessFile::read({:?}, {:?})", &this, &buf);
+        tracing::debug!("java.io.RandomAccessFile::read({this:?}, {buf:?})");
 
         let length = jvm.array_length(&buf).await?;
         let read = jvm.invoke_virtual(&this, "read", "([BII)I", (buf, 0, length as i32)).await?;
@@ -108,7 +108,7 @@ impl RandomAccessFile {
         offset: i32,
         length: i32,
     ) -> Result<i32> {
-        tracing::debug!("java.io.RandomAccessFile::read({:?}, {:?}, {:?}, {:?})", &this, &buf, &offset, &length);
+        tracing::debug!("java.io.RandomAccessFile::read({this:?}, {buf:?}, {offset:?}, {length:?})");
 
         let fd = jvm.get_field(&this, "fd", "Ljava/io/FileDescriptor;").await?;
         let mut rust_file = FileDescriptor::file(jvm, context, fd).await?;
@@ -122,7 +122,7 @@ impl RandomAccessFile {
     }
 
     async fn write(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, buf: ClassInstanceRef<Array<i8>>) -> Result<()> {
-        tracing::debug!("java.io.RandomAccessFile::write({:?}, {:?})", &this, &buf);
+        tracing::debug!("java.io.RandomAccessFile::write({this:?}, {buf:?})");
 
         let length = jvm.array_length(&buf).await?;
         let _: () = jvm.invoke_virtual(&this, "write", "([BII)V", (buf, 0, length as i32)).await?;
@@ -138,7 +138,7 @@ impl RandomAccessFile {
         offset: i32,
         length: i32,
     ) -> Result<()> {
-        tracing::debug!("java.io.RandomAccessFile::write({:?}, {:?}, {:?}, {:?})", &this, &buf, &offset, &length);
+        tracing::debug!("java.io.RandomAccessFile::write({this:?}, {buf:?}, {offset:?}, {length:?})");
 
         let fd = jvm.get_field(&this, "fd", "Ljava/io/FileDescriptor;").await?;
         let mut rust_file = FileDescriptor::file(jvm, context, fd).await?;
@@ -151,7 +151,7 @@ impl RandomAccessFile {
     }
 
     async fn seek(jvm: &Jvm, context: &mut RuntimeContext, this: ClassInstanceRef<Self>, pos: i64) -> Result<()> {
-        tracing::debug!("java.io.RandomAccessFile::seek({:?}, {:?})", &this, &pos);
+        tracing::debug!("java.io.RandomAccessFile::seek({this:?}, {pos:?})");
 
         let fd = jvm.get_field(&this, "fd", "Ljava/io/FileDescriptor;").await?;
         let mut rust_file = FileDescriptor::file(jvm, context, fd).await?;
@@ -162,7 +162,7 @@ impl RandomAccessFile {
     }
 
     async fn set_length(jvm: &Jvm, context: &mut RuntimeContext, this: ClassInstanceRef<Self>, new_length: i64) -> Result<()> {
-        tracing::debug!("java.io.RandomAccessFile::setLength({:?}, {:?})", &this, &new_length);
+        tracing::debug!("java.io.RandomAccessFile::setLength({this:?}, {new_length:?})");
 
         let fd = jvm.get_field(&this, "fd", "Ljava/io/FileDescriptor;").await?;
         let mut rust_file = FileDescriptor::file(jvm, context, fd).await?;
@@ -173,7 +173,7 @@ impl RandomAccessFile {
     }
 
     async fn length(jvm: &Jvm, context: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<i64> {
-        tracing::debug!("java.io.RandomAccessFile::length({:?})", &this);
+        tracing::debug!("java.io.RandomAccessFile::length({this:?})");
 
         let fd = jvm.get_field(&this, "fd", "Ljava/io/FileDescriptor;").await?;
         let rust_file = FileDescriptor::file(jvm, context, fd).await?;
@@ -184,7 +184,7 @@ impl RandomAccessFile {
     }
 
     async fn get_file_pointer(jvm: &Jvm, context: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<i64> {
-        tracing::debug!("java.io.RandomAccessFile::getFilePointer({:?})", &this);
+        tracing::debug!("java.io.RandomAccessFile::getFilePointer({this:?})");
 
         let fd = jvm.get_field(&this, "fd", "Ljava/io/FileDescriptor;").await?;
         let rust_file = FileDescriptor::file(jvm, context, fd).await?;
@@ -195,7 +195,7 @@ impl RandomAccessFile {
     }
 
     async fn get_fd(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<File>> {
-        tracing::debug!("java.io.RandomAccessFile::getFD({:?})", &this);
+        tracing::debug!("java.io.RandomAccessFile::getFD({this:?})");
 
         let fd = jvm.get_field(&this, "fd", "Ljava/io/FileDescriptor;").await?;
 
@@ -203,7 +203,7 @@ impl RandomAccessFile {
     }
 
     async fn close(jvm: &Jvm, context: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.io.RandomAccessFile::close({:?})", &this);
+        tracing::debug!("java.io.RandomAccessFile::close({this:?})");
 
         let fd = jvm.get_field(&this, "fd", "Ljava/io/FileDescriptor;").await?;
         FileDescriptor::close(jvm, context, fd).await?;

--- a/java_runtime/src/classes/java/io/reader.rs
+++ b/java_runtime/src/classes/java/io/reader.rs
@@ -27,7 +27,7 @@ impl Reader {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.io.Reader::<init>({:?})", &this);
+        tracing::debug!("java.io.Reader::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -35,7 +35,7 @@ impl Reader {
     }
 
     async fn read(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, buf: ClassInstanceRef<JavaChar>) -> Result<i32> {
-        tracing::debug!("java.io.Reader::read({:?}, {:?})", &this, &buf);
+        tracing::debug!("java.io.Reader::read({this:?}, {buf:?})");
 
         let len = jvm.array_length(&buf).await? as i32;
         let result = jvm.invoke_virtual(&this, "read", "([CII)I", (buf, 0, len)).await?;

--- a/java_runtime/src/classes/java/io/string_writer.rs
+++ b/java_runtime/src/classes/java/io/string_writer.rs
@@ -28,7 +28,7 @@ impl StringWriter {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.io.StringWriter::<init>({:?})", &this);
+        tracing::debug!("java.io.StringWriter::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/io/Writer", "<init>", "()V", ()).await?;
 
@@ -46,7 +46,7 @@ impl StringWriter {
         off: i32,
         len: i32,
     ) -> Result<i32> {
-        tracing::debug!("java.io.StringWriter::write({:?}, {:?}, {:?}, {:?})", &this, &chars, &off, &len);
+        tracing::debug!("java.io.StringWriter::write({this:?}, {chars:?}, {off:?}, {len:?})");
 
         let buf = jvm.get_field(&this, "buf", "Ljava/lang/StringBuffer;").await?;
 
@@ -58,7 +58,7 @@ impl StringWriter {
     }
 
     async fn to_string(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<String>> {
-        tracing::debug!("java.io.StringWriter::toString({:?})", &this);
+        tracing::debug!("java.io.StringWriter::toString({this:?})");
 
         let buf = jvm.get_field(&this, "buf", "Ljava/lang/StringBuffer;").await?;
 

--- a/java_runtime/src/classes/java/io/writer.rs
+++ b/java_runtime/src/classes/java/io/writer.rs
@@ -26,7 +26,7 @@ impl Writer {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.io.Writer::<init>({:?})", &this);
+        tracing::debug!("java.io.Writer::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -39,7 +39,7 @@ impl Writer {
         this: ClassInstanceRef<Self>,
         string: ClassInstanceRef<crate::classes::java::lang::String>,
     ) -> Result<()> {
-        tracing::debug!("java.io.Writer::write_string({:?}, {:?})", &this, &string);
+        tracing::debug!("java.io.Writer::write_string({this:?}, {string:?})");
 
         let chars: ClassInstanceRef<Array<JavaChar>> = jvm.invoke_virtual(&string, "toCharArray", "()[C", ()).await?;
         let length = jvm.array_length(&chars).await?;

--- a/java_runtime/src/classes/java/lang/abstract_method_error.rs
+++ b/java_runtime/src/classes/java/lang/abstract_method_error.rs
@@ -24,7 +24,7 @@ impl AbstractMethodError {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.AbstractMethodError::<init>({:?})", &this);
+        tracing::debug!("java.lang.AbstractMethodError::<init>({this:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/IncompatibleClassChangeError", "<init>", "()V", ())
@@ -34,7 +34,7 @@ impl AbstractMethodError {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.lang.AbstractMethodError::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.lang.AbstractMethodError::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(

--- a/java_runtime/src/classes/java/lang/arithmetic_exception.rs
+++ b/java_runtime/src/classes/java/lang/arithmetic_exception.rs
@@ -24,7 +24,7 @@ impl ArithmeticException {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.ArithmeticException::<init>({:?})", &this);
+        tracing::debug!("java.lang.ArithmeticException::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/RuntimeException", "<init>", "()V", ()).await?;
 
@@ -32,7 +32,7 @@ impl ArithmeticException {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.lang.ArithmeticException::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.lang.ArithmeticException::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/RuntimeException", "<init>", "(Ljava/lang/String;)V", (message,))

--- a/java_runtime/src/classes/java/lang/array_index_out_of_bounds_exception.rs
+++ b/java_runtime/src/classes/java/lang/array_index_out_of_bounds_exception.rs
@@ -24,7 +24,7 @@ impl ArrayIndexOutOfBoundsException {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.ArrayIndexOutOfBoundsException::<init>({:?})", &this);
+        tracing::debug!("java.lang.ArrayIndexOutOfBoundsException::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/RuntimeException", "<init>", "()V", ()).await?;
 
@@ -32,7 +32,7 @@ impl ArrayIndexOutOfBoundsException {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.lang.ArrayIndexOutOfBoundsException::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.lang.ArrayIndexOutOfBoundsException::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(

--- a/java_runtime/src/classes/java/lang/array_store_exception.rs
+++ b/java_runtime/src/classes/java/lang/array_store_exception.rs
@@ -24,7 +24,7 @@ impl ArrayStoreException {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.ArrayStoreException::<init>({:?})", &this);
+        tracing::debug!("java.lang.ArrayStoreException::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/RuntimeException", "<init>", "()V", ()).await?;
 
@@ -32,7 +32,7 @@ impl ArrayStoreException {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.lang.ArrayStoreException::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.lang.ArrayStoreException::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/RuntimeException", "<init>", "(Ljava/lang/String;)V", (message,))

--- a/java_runtime/src/classes/java/lang/class.rs
+++ b/java_runtime/src/classes/java/lang/class.rs
@@ -52,7 +52,7 @@ impl Class {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.Class::<init>({:?})", &this);
+        tracing::debug!("java.lang.Class::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -60,7 +60,7 @@ impl Class {
     }
 
     async fn get_name(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<String>> {
-        tracing::debug!("java.lang.Class::getName({:?})", &this);
+        tracing::debug!("java.lang.Class::getName({this:?})");
 
         let rust_class = JavaLangClass::to_rust_class(jvm, &this).await?;
         let result = JavaLangString::from_rust_string(jvm, &rust_class.name().replace('/', ".")).await?;
@@ -69,7 +69,7 @@ impl Class {
     }
 
     async fn is_assignable_from(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, other: ClassInstanceRef<Self>) -> Result<bool> {
-        tracing::debug!("java.lang.Class::isAssignableFrom({:?}, {:?})", &this, &other);
+        tracing::debug!("java.lang.Class::isAssignableFrom({this:?}, {other:?})");
 
         let rust_class = JavaLangClass::to_rust_class(jvm, &this).await?;
         let other_rust_class = JavaLangClass::to_rust_class(jvm, &other).await?;
@@ -83,7 +83,7 @@ impl Class {
         this: ClassInstanceRef<Self>,
         name: ClassInstanceRef<String>,
     ) -> Result<ClassInstanceRef<InputStream>> {
-        tracing::debug!("java.lang.Class::getResourceAsStream({:?}, {:?})", &this, &name);
+        tracing::debug!("java.lang.Class::getResourceAsStream({this:?}, {name:?})");
 
         let class_loader: ClassInstanceRef<ClassLoader> = jvm.get_field(&this, "classLoader", "Ljava/lang/ClassLoader;").await?;
 
@@ -99,7 +99,7 @@ impl Class {
     }
 
     async fn for_name(jvm: &Jvm, _context: &mut RuntimeContext, name: ClassInstanceRef<String>) -> Result<ClassInstanceRef<Class>> {
-        tracing::debug!("java.lang.Class::forName({:?})", &name);
+        tracing::debug!("java.lang.Class::forName({name:?})");
 
         let rust_name = JavaLangString::to_rust_string(jvm, &name).await?;
         let qualified_name = rust_name.replace('.', "/");

--- a/java_runtime/src/classes/java/lang/class_cast_exception.rs
+++ b/java_runtime/src/classes/java/lang/class_cast_exception.rs
@@ -24,7 +24,7 @@ impl ClassCastException {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.ClassCastException::<init>({:?})", &this);
+        tracing::debug!("java.lang.ClassCastException::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Exception", "<init>", "()V", ()).await?;
 
@@ -32,7 +32,7 @@ impl ClassCastException {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.lang.ClassCastException::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.lang.ClassCastException::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/Exception", "<init>", "(Ljava/lang/String;)V", (message,))

--- a/java_runtime/src/classes/java/lang/class_loader.rs
+++ b/java_runtime/src/classes/java/lang/class_loader.rs
@@ -71,7 +71,7 @@ impl ClassLoader {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, parent: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.ClassLoader::<init>({:?}, {:?})", &this, parent);
+        tracing::debug!("java.lang.ClassLoader::<init>({this:?}, {parent:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -158,7 +158,7 @@ impl ClassLoader {
         this: ClassInstanceRef<Self>,
         name: ClassInstanceRef<String>,
     ) -> Result<ClassInstanceRef<Class>> {
-        tracing::debug!("java.lang.ClassLoader::loadClass({:?}, {:?})", &this, name);
+        tracing::debug!("java.lang.ClassLoader::loadClass({this:?}, {name:?})");
 
         let class: ClassInstanceRef<Class> = jvm
             .invoke_virtual(&this, "findLoadedClass", "(Ljava/lang/String;)Ljava/lang/Class;", (name.clone(),))
@@ -203,7 +203,7 @@ impl ClassLoader {
         this: ClassInstanceRef<Self>,
         name: ClassInstanceRef<String>,
     ) -> Result<ClassInstanceRef<Class>> {
-        tracing::debug!("java.lang.ClassLoader::findClass({:?}, {:?})", &this, name);
+        tracing::debug!("java.lang.ClassLoader::findClass({this:?}, {name:?})");
 
         // TODO raise ClassNotFoundException
 
@@ -216,7 +216,7 @@ impl ClassLoader {
         this: ClassInstanceRef<Self>,
         name: ClassInstanceRef<String>,
     ) -> Result<ClassInstanceRef<Class>> {
-        tracing::debug!("java.lang.ClassLoader::findLoadedClass({:?}, {:?})", &this, name);
+        tracing::debug!("java.lang.ClassLoader::findLoadedClass({this:?}, {name:?})");
 
         let rust_name = JavaLangString::to_rust_string(jvm, &name).await?;
         if !jvm.has_class(&rust_name) {
@@ -234,7 +234,7 @@ impl ClassLoader {
         this: ClassInstanceRef<Self>,
         name: ClassInstanceRef<String>,
     ) -> Result<ClassInstanceRef<URL>> {
-        tracing::debug!("java.lang.ClassLoader::getResource({:?})", &this);
+        tracing::debug!("java.lang.ClassLoader::getResource({this:?})");
 
         let parent: ClassInstanceRef<Self> = jvm.get_field(&this, "parent", "Ljava/lang/ClassLoader;").await?;
 
@@ -262,7 +262,7 @@ impl ClassLoader {
         this: ClassInstanceRef<Self>,
         name: ClassInstanceRef<String>,
     ) -> Result<ClassInstanceRef<URL>> {
-        tracing::debug!("java.lang.ClassLoader::getResourceAsStream({:?})", &this);
+        tracing::debug!("java.lang.ClassLoader::getResourceAsStream({this:?})");
 
         let resource_url: ClassInstanceRef<URL> = jvm
             .invoke_virtual(&this, "getResource", "(Ljava/lang/String;)Ljava/net/URL;", (name.clone(),))
@@ -283,7 +283,7 @@ impl ClassLoader {
         this: ClassInstanceRef<Self>,
         _: ClassInstanceRef<String>,
     ) -> Result<ClassInstanceRef<URL>> {
-        tracing::debug!("java.lang.ClassLoader::findResource({:?})", &this);
+        tracing::debug!("java.lang.ClassLoader::findResource({this:?})");
 
         Ok(None.into())
     }
@@ -297,14 +297,7 @@ impl ClassLoader {
         offset: i32,
         length: i32,
     ) -> Result<ClassInstanceRef<Class>> {
-        tracing::debug!(
-            "java.lang.ClassLoader::defineClass({:?}, {:?}, {:?}, {:?}, {:?})",
-            &this,
-            name,
-            bytes,
-            offset,
-            length
-        );
+        tracing::debug!("java.lang.ClassLoader::defineClass({this:?}, {name:?}, {bytes:?}, {offset:?}, {length:?})");
 
         let mut data = vec![0; length as usize];
         jvm.array_raw_buffer(&bytes).await?.read(offset as _, &mut data)?;

--- a/java_runtime/src/classes/java/lang/clone_not_supported_exception.rs
+++ b/java_runtime/src/classes/java/lang/clone_not_supported_exception.rs
@@ -24,7 +24,7 @@ impl CloneNotSupportedException {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.CloneNotSupportedException::<init>({:?})", &this);
+        tracing::debug!("java.lang.CloneNotSupportedException::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Exception", "<init>", "()V", ()).await?;
 
@@ -32,7 +32,7 @@ impl CloneNotSupportedException {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.lang.CloneNotSupportedException::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.lang.CloneNotSupportedException::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/Exception", "<init>", "(Ljava/lang/String;)V", (message,))

--- a/java_runtime/src/classes/java/lang/error.rs
+++ b/java_runtime/src/classes/java/lang/error.rs
@@ -24,7 +24,7 @@ impl Error {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.Error::<init>({:?})", &this);
+        tracing::debug!("java.lang.Error::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Throwable", "<init>", "()V", ()).await?;
 
@@ -32,7 +32,7 @@ impl Error {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.lang.Error::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.lang.Error::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/Throwable", "<init>", "(Ljava/lang/String;)V", (message,))

--- a/java_runtime/src/classes/java/lang/exception.rs
+++ b/java_runtime/src/classes/java/lang/exception.rs
@@ -34,7 +34,7 @@ impl Exception {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.Exception::<init>({:?})", &this);
+        tracing::debug!("java.lang.Exception::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Throwable", "<init>", "()V", ()).await?;
 
@@ -42,7 +42,7 @@ impl Exception {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.lang.Exception::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.lang.Exception::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/Throwable", "<init>", "(Ljava/lang/String;)V", (message,))
@@ -52,7 +52,7 @@ impl Exception {
     }
 
     async fn init_with_cause(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, cause: ClassInstanceRef<Throwable>) -> Result<()> {
-        tracing::debug!("java.lang.Exception::<init>({:?}, {:?})", &this, &cause);
+        tracing::debug!("java.lang.Exception::<init>({this:?}, {cause:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/Throwable", "<init>", "(Ljava/lang/Throwable;)V", (cause,))
@@ -68,7 +68,7 @@ impl Exception {
         message: ClassInstanceRef<String>,
         cause: ClassInstanceRef<Throwable>,
     ) -> Result<()> {
-        tracing::debug!("java.lang.Exception::<init>({:?}, {:?}, {:?})", &this, &message, &cause);
+        tracing::debug!("java.lang.Exception::<init>({this:?}, {message:?}, {cause:?})");
 
         let _: () = jvm
             .invoke_special(

--- a/java_runtime/src/classes/java/lang/exception_in_initializer_error.rs
+++ b/java_runtime/src/classes/java/lang/exception_in_initializer_error.rs
@@ -29,7 +29,7 @@ impl ExceptionInInitializerError {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.ExceptionInInitializerError::<init>({:?})", &this);
+        tracing::debug!("java.lang.ExceptionInInitializerError::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/LinkageError", "<init>", "()V", ()).await?;
 
@@ -37,7 +37,7 @@ impl ExceptionInInitializerError {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.lang.ExceptionInInitializerError::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.lang.ExceptionInInitializerError::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/LinkageError", "<init>", "(Ljava/lang/String;)V", (message,))
@@ -47,7 +47,7 @@ impl ExceptionInInitializerError {
     }
 
     async fn init_with_cause(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, cause: ClassInstanceRef<Throwable>) -> Result<()> {
-        tracing::debug!("java.lang.ExceptionInInitializerError::<init>({:?}, {:?})", &this, &cause);
+        tracing::debug!("java.lang.ExceptionInInitializerError::<init>({this:?}, {cause:?})");
 
         // unlike Throwable(Throwable), this keeps detailMessage null so toString is just the class name
         let _: () = jvm.invoke_special(&this, "java/lang/LinkageError", "<init>", "()V", ()).await?;
@@ -58,7 +58,7 @@ impl ExceptionInInitializerError {
     }
 
     async fn get_exception(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<Throwable>> {
-        tracing::debug!("java.lang.ExceptionInInitializerError::getException({:?})", &this);
+        tracing::debug!("java.lang.ExceptionInInitializerError::getException({this:?})");
 
         jvm.get_field(&this, "cause", "Ljava/lang/Throwable;").await
     }

--- a/java_runtime/src/classes/java/lang/illegal_argument_exception.rs
+++ b/java_runtime/src/classes/java/lang/illegal_argument_exception.rs
@@ -24,7 +24,7 @@ impl IllegalArgumentException {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.IllegalArgumentException::<init>({:?})", &this);
+        tracing::debug!("java.lang.IllegalArgumentException::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/RuntimeException", "<init>", "()V", ()).await?;
 
@@ -32,7 +32,7 @@ impl IllegalArgumentException {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.lang.IllegalArgumentException::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.lang.IllegalArgumentException::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/RuntimeException", "<init>", "(Ljava/lang/String;)V", (message,))

--- a/java_runtime/src/classes/java/lang/incompatible_class_change_error.rs
+++ b/java_runtime/src/classes/java/lang/incompatible_class_change_error.rs
@@ -24,7 +24,7 @@ impl IncompatibleClassChangeError {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.IncompatibleClassChangeError::<init>({:?})", &this);
+        tracing::debug!("java.lang.IncompatibleClassChangeError::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/LinkageError", "<init>", "()V", ()).await?;
 
@@ -32,7 +32,7 @@ impl IncompatibleClassChangeError {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.lang.IncompatibleClassChangeError::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.lang.IncompatibleClassChangeError::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/LinkageError", "<init>", "(Ljava/lang/String;)V", (message,))

--- a/java_runtime/src/classes/java/lang/index_out_of_bounds_exception.rs
+++ b/java_runtime/src/classes/java/lang/index_out_of_bounds_exception.rs
@@ -24,7 +24,7 @@ impl IndexOutOfBoundsException {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.IndexOutOfBoundsException::<init>({:?})", &this);
+        tracing::debug!("java.lang.IndexOutOfBoundsException::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/RuntimeException", "<init>", "()V", ()).await?;
 
@@ -32,7 +32,7 @@ impl IndexOutOfBoundsException {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.lang.IndexOutOfBoundsException::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.lang.IndexOutOfBoundsException::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/RuntimeException", "<init>", "(Ljava/lang/String;)V", (message,))

--- a/java_runtime/src/classes/java/lang/instantiation_error.rs
+++ b/java_runtime/src/classes/java/lang/instantiation_error.rs
@@ -24,7 +24,7 @@ impl InstantiationError {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.InstantiationError::<init>({:?})", &this);
+        tracing::debug!("java.lang.InstantiationError::<init>({this:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/IncompatibleClassChangeError", "<init>", "()V", ())
@@ -34,7 +34,7 @@ impl InstantiationError {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.lang.InstantiationError::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.lang.InstantiationError::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(

--- a/java_runtime/src/classes/java/lang/integer.rs
+++ b/java_runtime/src/classes/java/lang/integer.rs
@@ -30,7 +30,7 @@ impl Integer {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, value: i32) -> Result<()> {
-        tracing::debug!("java.lang.Integer::<init>({:?}, {:?})", &this, value);
+        tracing::debug!("java.lang.Integer::<init>({this:?}, {value:?})");
 
         jvm.put_field(&mut this, "value", "I", value).await?;
 
@@ -38,7 +38,7 @@ impl Integer {
     }
 
     async fn int_value(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<i32> {
-        tracing::debug!("java.lang.Integer::intValue({:?})", &this);
+        tracing::debug!("java.lang.Integer::intValue({this:?})");
 
         let value = jvm.get_field(&this, "value", "I").await?;
 
@@ -46,7 +46,7 @@ impl Integer {
     }
 
     async fn value_of(jvm: &Jvm, _: &mut RuntimeContext, value: i32) -> Result<ClassInstanceRef<Self>> {
-        tracing::debug!("java.lang.Integer::valueOf({:?})", value);
+        tracing::debug!("java.lang.Integer::valueOf({value:?})");
 
         let instance = jvm.new_class("java/lang/Integer", "(I)V", (value,)).await?;
 
@@ -54,7 +54,7 @@ impl Integer {
     }
 
     async fn to_string(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<String>> {
-        tracing::debug!("java.lang.Integer::toString({:?})", &this);
+        tracing::debug!("java.lang.Integer::toString({this:?})");
 
         let value: i32 = jvm.get_field(&this, "value", "I").await?;
 
@@ -64,7 +64,7 @@ impl Integer {
     }
 
     async fn to_string_static(jvm: &Jvm, _: &mut RuntimeContext, value: i32) -> Result<ClassInstanceRef<String>> {
-        tracing::debug!("java.lang.Integer::toString({:?})", value);
+        tracing::debug!("java.lang.Integer::toString({value:?})");
 
         let string = JavaLangString::from_rust_string(jvm, &value.to_string()).await?;
 
@@ -72,7 +72,7 @@ impl Integer {
     }
 
     async fn parse_int(jvm: &Jvm, _: &mut RuntimeContext, s: ClassInstanceRef<String>) -> Result<i32> {
-        tracing::debug!("java.lang.Integer::parseInt({:?})", &s);
+        tracing::debug!("java.lang.Integer::parseInt({s:?})");
 
         let s = JavaLangString::to_rust_string(jvm, &s).await?;
 
@@ -85,7 +85,7 @@ impl Integer {
     }
 
     async fn to_hex_string(jvm: &Jvm, _: &mut RuntimeContext, value: i32) -> Result<ClassInstanceRef<String>> {
-        tracing::debug!("java.lang.Integer::toHexString({:?})", value);
+        tracing::debug!("java.lang.Integer::toHexString({value:?})");
 
         let string = JavaLangString::from_rust_string(jvm, &format!("{value:x}")).await?;
 

--- a/java_runtime/src/classes/java/lang/interrupted_exception.rs
+++ b/java_runtime/src/classes/java/lang/interrupted_exception.rs
@@ -24,7 +24,7 @@ impl InterruptedException {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.InterruptedException::<init>({:?})", &this);
+        tracing::debug!("java.lang.InterruptedException::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Exception", "<init>", "()V", ()).await?;
 
@@ -32,7 +32,7 @@ impl InterruptedException {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.lang.InterruptedException::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.lang.InterruptedException::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/Exception", "<init>", "(Ljava/lang/String;)V", (message,))

--- a/java_runtime/src/classes/java/lang/linkage_error.rs
+++ b/java_runtime/src/classes/java/lang/linkage_error.rs
@@ -24,7 +24,7 @@ impl LinkageError {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.LinkageError::<init>({:?})", &this);
+        tracing::debug!("java.lang.LinkageError::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Error", "<init>", "()V", ()).await?;
 
@@ -32,7 +32,7 @@ impl LinkageError {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.lang.LinkageError::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.lang.LinkageError::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/Error", "<init>", "(Ljava/lang/String;)V", (message,))

--- a/java_runtime/src/classes/java/lang/negative_array_size_exception.rs
+++ b/java_runtime/src/classes/java/lang/negative_array_size_exception.rs
@@ -23,7 +23,7 @@ impl NegativeArraySizeException {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.NegativeArraySizeException::<init>({:?})", &this);
+        tracing::debug!("java.lang.NegativeArraySizeException::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/RuntimeException", "<init>", "()V", ()).await?;
 
@@ -31,7 +31,7 @@ impl NegativeArraySizeException {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.lang.NegativeArraySizeException::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.lang.NegativeArraySizeException::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/RuntimeException", "<init>", "(Ljava/lang/String;)V", (message,))

--- a/java_runtime/src/classes/java/lang/no_class_def_found_error.rs
+++ b/java_runtime/src/classes/java/lang/no_class_def_found_error.rs
@@ -24,7 +24,7 @@ impl NoClassDefFoundError {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.NoClassDefFoundError::<init>({:?})", &this);
+        tracing::debug!("java.lang.NoClassDefFoundError::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/LinkageError", "<init>", "()V", ()).await?;
 
@@ -32,7 +32,7 @@ impl NoClassDefFoundError {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.lang.NoClassDefFoundError::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.lang.NoClassDefFoundError::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/LinkageError", "<init>", "(Ljava/lang/String;)V", (message,))

--- a/java_runtime/src/classes/java/lang/no_such_field_error.rs
+++ b/java_runtime/src/classes/java/lang/no_such_field_error.rs
@@ -24,7 +24,7 @@ impl NoSuchFieldError {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.NoSuchFieldError::<init>({:?})", &this);
+        tracing::debug!("java.lang.NoSuchFieldError::<init>({this:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/IncompatibleClassChangeError", "<init>", "()V", ())
@@ -34,7 +34,7 @@ impl NoSuchFieldError {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.lang.NoSuchFieldError::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.lang.NoSuchFieldError::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(

--- a/java_runtime/src/classes/java/lang/no_such_method_error.rs
+++ b/java_runtime/src/classes/java/lang/no_such_method_error.rs
@@ -24,7 +24,7 @@ impl NoSuchMethodError {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.NoSuchMethodError::<init>({:?})", &this);
+        tracing::debug!("java.lang.NoSuchMethodError::<init>({this:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/IncompatibleClassChangeError", "<init>", "()V", ())
@@ -34,7 +34,7 @@ impl NoSuchMethodError {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.lang.NoSuchMethodError::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.lang.NoSuchMethodError::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(

--- a/java_runtime/src/classes/java/lang/null_pointer_exception.rs
+++ b/java_runtime/src/classes/java/lang/null_pointer_exception.rs
@@ -24,7 +24,7 @@ impl NullPointerException {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.NullPointerException::<init>({:?})", &this);
+        tracing::debug!("java.lang.NullPointerException::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/RuntimeException", "<init>", "()V", ()).await?;
 
@@ -32,7 +32,7 @@ impl NullPointerException {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.lang.NullPointerException::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.lang.NullPointerException::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/RuntimeException", "<init>", "(Ljava/lang/String;)V", (message,))

--- a/java_runtime/src/classes/java/lang/number_format_exception.rs
+++ b/java_runtime/src/classes/java/lang/number_format_exception.rs
@@ -24,7 +24,7 @@ impl NumberFormatException {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.NumberFormatException::<init>({:?})", &this);
+        tracing::debug!("java.lang.NumberFormatException::<init>({this:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/IllegalArgumentException", "<init>", "()V", ())
@@ -34,7 +34,7 @@ impl NumberFormatException {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.lang.NumberFormatException::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.lang.NumberFormatException::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/IllegalArgumentException", "<init>", "(Ljava/lang/String;)V", (message,))

--- a/java_runtime/src/classes/java/lang/object.rs
+++ b/java_runtime/src/classes/java/lang/object.rs
@@ -62,13 +62,13 @@ impl Object {
     }
 
     async fn init(_: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.Object::<init>({:?})", &this);
+        tracing::debug!("java.lang.Object::<init>({this:?})");
 
         Ok(())
     }
 
     async fn get_class(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<Self>> {
-        tracing::debug!("java.lang.Object::getClass({:?})", &this);
+        tracing::debug!("java.lang.Object::getClass({this:?})");
 
         // TODO can we get class directly?
         let this: Box<dyn ClassInstance> = this.into();
@@ -80,7 +80,7 @@ impl Object {
     }
 
     async fn hash_code(_: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<i32> {
-        tracing::debug!("java.lang.Object::hashCode({:?})", &this);
+        tracing::debug!("java.lang.Object::hashCode({this:?})");
 
         let rust_this: Box<dyn ClassInstance> = this.into();
 
@@ -92,7 +92,7 @@ impl Object {
     }
 
     async fn equals(_: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, other: ClassInstanceRef<Self>) -> Result<bool> {
-        tracing::debug!("java.lang.Object::equals({:?}, {:?})", &this, &other);
+        tracing::debug!("java.lang.Object::equals({this:?}, {other:?})");
 
         if other.is_null() {
             return Ok(false);
@@ -105,7 +105,7 @@ impl Object {
     }
 
     async fn clone(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<Self>> {
-        tracing::warn!("stub java.lang.Object::clone({:?})", &this);
+        tracing::warn!("stub java.lang.Object::clone({this:?})");
 
         if !jvm.is_instance(&**this, "java/lang/Cloneable") {
             return Err(jvm.exception("java/lang/CloneNotSupportedException", "Cannot clone this object").await);
@@ -115,7 +115,7 @@ impl Object {
     }
 
     async fn to_string(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<String>> {
-        tracing::debug!("java.lang.Object::toString({:?})", &this);
+        tracing::debug!("java.lang.Object::toString({this:?})");
 
         let class = jvm.invoke_virtual(&this, "getClass", "()Ljava/lang/Class;", ()).await?;
         let class_name = jvm.invoke_virtual(&class, "getName", "()Ljava/lang/String;", ()).await?;
@@ -129,7 +129,7 @@ impl Object {
     }
 
     async fn notify(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.Object::notify({:?})", &this);
+        tracing::debug!("java.lang.Object::notify({this:?})");
 
         jvm.object_notify(&this, 1);
 
@@ -137,7 +137,7 @@ impl Object {
     }
 
     async fn notify_all(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.Object::notifyAll({:?})", &this);
+        tracing::debug!("java.lang.Object::notifyAll({this:?})");
 
         jvm.object_notify(&this, usize::MAX);
 
@@ -145,7 +145,7 @@ impl Object {
     }
 
     async fn wait_long(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, millis: i64) -> Result<()> {
-        tracing::debug!("java.lang.Object::wait({:?}, {:?})", &this, millis);
+        tracing::debug!("java.lang.Object::wait({this:?}, {millis:?})");
 
         let _: () = jvm.invoke_virtual(&this, "wait", "(JI)V", (millis, 0)).await?;
 
@@ -153,7 +153,7 @@ impl Object {
     }
 
     async fn wait_long_int(jvm: &Jvm, context: &mut RuntimeContext, this: ClassInstanceRef<Self>, millis: i64, nanos: i32) -> Result<()> {
-        tracing::debug!("java.lang.Object::wait({:?}, {:?}, {:?})", &this, millis, nanos);
+        tracing::debug!("java.lang.Object::wait({this:?}, {millis:?}, {nanos:?})");
 
         struct TimeoutNotifier {
             timeout: i64,
@@ -190,7 +190,7 @@ impl Object {
     }
 
     async fn wait(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.Object::wait({:?})", &this);
+        tracing::debug!("java.lang.Object::wait({this:?})");
 
         let _: () = jvm.invoke_virtual(&this, "wait", "(JI)V", (0i64, 0)).await?;
 
@@ -198,7 +198,7 @@ impl Object {
     }
 
     async fn finalize(_: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::warn!("stub java.lang.Object::finalize({:?})", &this);
+        tracing::warn!("stub java.lang.Object::finalize({this:?})");
 
         Ok(())
     }

--- a/java_runtime/src/classes/java/lang/runtime.rs
+++ b/java_runtime/src/classes/java/lang/runtime.rs
@@ -28,7 +28,7 @@ impl Runtime {
     }
 
     async fn init(_: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Runtime>) -> Result<()> {
-        tracing::warn!("stub java.lang.Runtime::<init>({:?})", &this);
+        tracing::warn!("stub java.lang.Runtime::<init>({this:?})");
 
         Ok(())
     }
@@ -42,19 +42,19 @@ impl Runtime {
     }
 
     async fn total_memory(_: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Runtime>) -> Result<i64> {
-        tracing::warn!("stub java.lang.Runtime::totalMemory({:?})", &this);
+        tracing::warn!("stub java.lang.Runtime::totalMemory({this:?})");
 
         Ok(0x100000) // TODO: hardcoded
     }
 
     async fn free_memory(_: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Runtime>) -> Result<i64> {
-        tracing::warn!("stub java.lang.Runtime::freeMemory({:?})", &this);
+        tracing::warn!("stub java.lang.Runtime::freeMemory({this:?})");
 
         Ok(0x100000) // TODO: hardcoded
     }
 
     async fn gc(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Runtime>) -> Result<()> {
-        tracing::debug!("java.lang.Runtime::gc({:?})", &this);
+        tracing::debug!("java.lang.Runtime::gc({this:?})");
 
         jvm.collect_garbage()?;
 

--- a/java_runtime/src/classes/java/lang/runtime_exception.rs
+++ b/java_runtime/src/classes/java/lang/runtime_exception.rs
@@ -34,7 +34,7 @@ impl RuntimeException {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.RuntimeException::<init>({:?})", &this);
+        tracing::debug!("java.lang.RuntimeException::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Exception", "<init>", "()V", ()).await?;
 
@@ -42,7 +42,7 @@ impl RuntimeException {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.lang.RuntimeException::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.lang.RuntimeException::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/Exception", "<init>", "(Ljava/lang/String;)V", (message,))
@@ -52,7 +52,7 @@ impl RuntimeException {
     }
 
     async fn init_with_cause(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, cause: ClassInstanceRef<Throwable>) -> Result<()> {
-        tracing::debug!("java.lang.RuntimeException::<init>({:?}, {:?})", &this, &cause);
+        tracing::debug!("java.lang.RuntimeException::<init>({this:?}, {cause:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/Exception", "<init>", "(Ljava/lang/Throwable;)V", (cause,))
@@ -68,7 +68,7 @@ impl RuntimeException {
         message: ClassInstanceRef<String>,
         cause: ClassInstanceRef<Throwable>,
     ) -> Result<()> {
-        tracing::debug!("java.lang.RuntimeException::<init>({:?}, {:?}, {:?})", &this, &message, &cause);
+        tracing::debug!("java.lang.RuntimeException::<init>({this:?}, {message:?}, {cause:?})");
 
         let _: () = jvm
             .invoke_special(

--- a/java_runtime/src/classes/java/lang/security_exception.rs
+++ b/java_runtime/src/classes/java/lang/security_exception.rs
@@ -24,7 +24,7 @@ impl SecurityException {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.SecurityException::<init>({:?})", &this);
+        tracing::debug!("java.lang.SecurityException::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/RuntimeException", "<init>", "()V", ()).await?;
 
@@ -32,7 +32,7 @@ impl SecurityException {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.lang.SecurityException::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.lang.SecurityException::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/RuntimeException", "<init>", "(Ljava/lang/String;)V", (message,))

--- a/java_runtime/src/classes/java/lang/string.rs
+++ b/java_runtime/src/classes/java/lang/string.rs
@@ -104,7 +104,7 @@ impl String {
     }
 
     async fn init_with_byte_array(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, value: ClassInstanceRef<Array<i8>>) -> Result<()> {
-        tracing::debug!("java.lang.String::<init>({:?}, {:?})", &this, &value);
+        tracing::debug!("java.lang.String::<init>({this:?}, {value:?})");
 
         let count = jvm.array_length(&value).await? as i32;
 
@@ -121,7 +121,7 @@ impl String {
         this: ClassInstanceRef<Self>,
         value: ClassInstanceRef<Array<u16>>,
     ) -> Result<()> {
-        tracing::debug!("java.lang.String::<init>({:?}, {:?})", &this, &value);
+        tracing::debug!("java.lang.String::<init>({this:?}, {value:?})");
 
         let count = jvm.array_length(&value).await? as i32;
 
@@ -140,7 +140,7 @@ impl String {
         offset: i32,
         count: i32,
     ) -> Result<()> {
-        tracing::debug!("java.lang.String::<init>({:?}, {:?}, {}, {})", &this, &value, offset, count);
+        tracing::debug!("java.lang.String::<init>({this:?}, {value:?}, {offset}, {count})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -161,7 +161,7 @@ impl String {
         offset: i32,
         count: i32,
     ) -> Result<()> {
-        tracing::debug!("java.lang.String::<init>({:?}, {:?}, {}, {})", &this, &value, offset, count);
+        tracing::debug!("java.lang.String::<init>({this:?}, {value:?}, {offset}, {count})");
 
         let bytes: Vec<i8> = jvm.load_array(&value, offset as _, count as _).await?;
 
@@ -179,7 +179,7 @@ impl String {
     }
 
     async fn init_with_string(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, value: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.String::<init>({:?}, {:?})", &this, &value);
+        tracing::debug!("java.lang.String::<init>({this:?}, {value:?})");
 
         let chars: ClassInstanceRef<Array<JavaChar>> = jvm.invoke_virtual(&value, "toCharArray", "()[C", ()).await?;
 
@@ -194,7 +194,7 @@ impl String {
         this: ClassInstanceRef<Self>,
         value: ClassInstanceRef<StringBuffer>,
     ) -> Result<()> {
-        tracing::debug!("java.lang.String::<init>({:?}, {:?})", &this, &value);
+        tracing::debug!("java.lang.String::<init>({this:?}, {value:?})");
 
         let string: ClassInstanceRef<Self> = jvm.invoke_virtual(&value, "toString", "()Ljava/lang/String;", ()).await?;
 
@@ -206,7 +206,7 @@ impl String {
     }
 
     async fn equals(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, other: ClassInstanceRef<Self>) -> Result<bool> {
-        tracing::debug!("java.lang.String::equals({:?}, {:?})", &this, &other);
+        tracing::debug!("java.lang.String::equals({this:?}, {other:?})");
 
         if other.is_null() {
             return Ok(false);
@@ -219,7 +219,7 @@ impl String {
     }
 
     async fn compare_to(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, other: ClassInstanceRef<Self>) -> Result<i32> {
-        tracing::debug!("java.lang.String::compareTo({:?}, {:?})", &this, &other);
+        tracing::debug!("java.lang.String::compareTo({this:?}, {other:?})");
 
         let other_string = JavaLangString::to_rust_string(jvm, &other).await?;
         let this_string = JavaLangString::to_rust_string(jvm, &this).await?;
@@ -234,7 +234,7 @@ impl String {
     }
 
     async fn hash_code(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<i32> {
-        tracing::debug!("java.lang.String::hashCode({:?})", &this);
+        tracing::debug!("java.lang.String::hashCode({this:?})");
 
         let chars = jvm.get_field(&this, "value", "[C").await?;
         let chars: Vec<JavaChar> = jvm.load_array(&chars, 0, jvm.array_length(&chars).await? as _).await?;
@@ -245,13 +245,13 @@ impl String {
     }
 
     async fn to_string(_jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<Self>> {
-        tracing::debug!("java.lang.String::toString({:?})", &this);
+        tracing::debug!("java.lang.String::toString({this:?})");
 
         Ok(this)
     }
 
     async fn char_at(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, index: i32) -> Result<u16> {
-        tracing::debug!("java.lang.String::charAt({:?}, {})", &this, index);
+        tracing::debug!("java.lang.String::charAt({this:?}, {index})");
 
         let value = jvm.get_field(&this, "value", "[C").await?;
 
@@ -264,7 +264,7 @@ impl String {
         this: ClassInstanceRef<Self>,
         other: ClassInstanceRef<Self>,
     ) -> Result<ClassInstanceRef<Self>> {
-        tracing::debug!("java.lang.String::concat({:?}, {:?})", &this, &other);
+        tracing::debug!("java.lang.String::concat({this:?}, {other:?})");
 
         let this_string = JavaLangString::to_rust_string(jvm, &this.clone()).await?;
         let other_string = JavaLangString::to_rust_string(jvm, &other.clone()).await?;
@@ -275,7 +275,7 @@ impl String {
     }
 
     async fn get_bytes(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<Array<i8>>> {
-        tracing::debug!("java.lang.String::getBytes({:?})", &this);
+        tracing::debug!("java.lang.String::getBytes({this:?})");
 
         let string = JavaLangString::to_rust_string(jvm, &this.clone()).await?;
 
@@ -297,14 +297,7 @@ impl String {
         mut dst: ClassInstanceRef<Array<JavaChar>>,
         dst_begin: i32,
     ) -> Result<()> {
-        tracing::debug!(
-            "java.lang.String::getChars({:?}, {}, {}, {:?}, {})",
-            &this,
-            src_begin,
-            src_end,
-            &dst,
-            dst_begin
-        );
+        tracing::debug!("java.lang.String::getChars({this:?}, {src_begin}, {src_end}, {dst:?}, {dst_begin})");
 
         let value = jvm.get_field(&this, "value", "[C").await?;
 
@@ -316,7 +309,7 @@ impl String {
     }
 
     async fn to_char_array(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<Array<JavaChar>>> {
-        tracing::debug!("java.lang.String::toCharArray({:?})", &this);
+        tracing::debug!("java.lang.String::toCharArray({this:?})");
 
         let value = jvm.get_field(&this, "value", "[C").await?;
 
@@ -324,7 +317,7 @@ impl String {
     }
 
     async fn length(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<i32> {
-        tracing::debug!("java.lang.String::length({:?})", &this);
+        tracing::debug!("java.lang.String::length({this:?})");
 
         let value = jvm.get_field(&this, "value", "[C").await?;
 
@@ -332,7 +325,7 @@ impl String {
     }
 
     async fn substring(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, begin_index: i32) -> Result<ClassInstanceRef<Self>> {
-        tracing::debug!("java.lang.String::substring({:?}, {})", &this, begin_index);
+        tracing::debug!("java.lang.String::substring({this:?}, {begin_index})");
 
         let string = JavaLangString::to_rust_string(jvm, &this.clone()).await?;
 
@@ -361,7 +354,7 @@ impl String {
         begin_index: i32,
         end_index: i32,
     ) -> Result<ClassInstanceRef<Self>> {
-        tracing::debug!("java.lang.String::substring({:?}, {}, {})", &this, begin_index, end_index);
+        tracing::debug!("java.lang.String::substring({this:?}, {begin_index}, {end_index})");
 
         let string = JavaLangString::to_rust_string(jvm, &this.clone()).await?;
 
@@ -384,7 +377,7 @@ impl String {
     }
 
     async fn value_of_char(jvm: &Jvm, _: &mut RuntimeContext, value: JavaChar) -> Result<ClassInstanceRef<Self>> {
-        tracing::debug!("java.lang.String::valueOf({})", value);
+        tracing::debug!("java.lang.String::valueOf({value})");
 
         let string = RustString::from_utf16(&[value]).unwrap();
 
@@ -392,7 +385,7 @@ impl String {
     }
 
     async fn value_of_integer(jvm: &Jvm, _: &mut RuntimeContext, value: i32) -> Result<ClassInstanceRef<Self>> {
-        tracing::debug!("java.lang.String::valueOf({})", value);
+        tracing::debug!("java.lang.String::valueOf({value})");
 
         let string = value.to_string();
 
@@ -400,7 +393,7 @@ impl String {
     }
 
     async fn value_of_object(jvm: &Jvm, _: &mut RuntimeContext, value: ClassInstanceRef<Object>) -> Result<ClassInstanceRef<Self>> {
-        tracing::warn!("stub java.lang.String::valueOf({:?})", &value);
+        tracing::warn!("stub java.lang.String::valueOf({value:?})");
 
         Ok(if value.is_null() {
             JavaLangString::from_rust_string(jvm, "null").await?.into()
@@ -410,13 +403,13 @@ impl String {
     }
 
     async fn index_of(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, ch: i32) -> Result<i32> {
-        tracing::debug!("java.lang.String::indexOf({:?}, {:?})", &this, ch);
+        tracing::debug!("java.lang.String::indexOf({this:?}, {ch:?})");
 
         jvm.invoke_virtual(&this, "indexOf", "(II)I", (ch, 0)).await
     }
 
     async fn index_of_from(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, ch: i32, from_index: i32) -> Result<i32> {
-        tracing::debug!("java.lang.String::indexOf({:?}, {:?}, {:?})", &this, ch, from_index);
+        tracing::debug!("java.lang.String::indexOf({this:?}, {ch:?}, {from_index:?})");
 
         let this_string = JavaLangString::to_rust_string(jvm, &this.clone()).await?;
 
@@ -430,7 +423,7 @@ impl String {
     }
 
     async fn index_of_string(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, str: ClassInstanceRef<Self>) -> Result<i32> {
-        tracing::debug!("java.lang.String::indexOf({:?}, {:?})", &this, &str);
+        tracing::debug!("java.lang.String::indexOf({this:?}, {str:?})");
 
         jvm.invoke_virtual(&this, "indexOf", "(Ljava/lang/String;I)I", (str, 0)).await
     }
@@ -442,13 +435,13 @@ impl String {
         str: ClassInstanceRef<Self>,
         from_index: i32,
     ) -> Result<i32> {
-        tracing::debug!("java.lang.String::indexOf({:?}, {:?}, {})", &this, &str, from_index);
+        tracing::debug!("java.lang.String::indexOf({this:?}, {str:?}, {from_index})");
 
         let this_string = JavaLangString::to_rust_string(jvm, &this.clone()).await?;
         let str_string = JavaLangString::to_rust_string(jvm, &str.clone()).await?;
 
-        tracing::trace!("this_string: {:?}", this_string);
-        tracing::trace!("str_string: {:?}", str_string);
+        tracing::trace!("this_string: {this_string:?}");
+        tracing::trace!("str_string: {str_string:?}");
 
         let chars = this_string.chars().skip(from_index as usize).collect::<Vec<_>>();
         let str_chars = str_string.chars().collect::<Vec<_>>();
@@ -458,7 +451,7 @@ impl String {
     }
 
     async fn last_index_of(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, ch: i32) -> Result<i32> {
-        tracing::debug!("java.lang.String::lastIndexOf({:?}, {:?})", &this, ch);
+        tracing::debug!("java.lang.String::lastIndexOf({this:?}, {ch:?})");
 
         let this_string = JavaLangString::to_rust_string(jvm, &this.clone()).await?;
 
@@ -473,7 +466,7 @@ impl String {
     }
 
     async fn trim(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<Self>> {
-        tracing::debug!("java.lang.String::trim({:?})", &this);
+        tracing::debug!("java.lang.String::trim({this:?})");
 
         let string = JavaLangString::to_rust_string(jvm, &this.clone()).await?;
 
@@ -483,7 +476,7 @@ impl String {
     }
 
     async fn to_upper_case(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<Self>> {
-        tracing::debug!("java.lang.String::toUpperCase({:?})", &this);
+        tracing::debug!("java.lang.String::toUpperCase({this:?})");
 
         let string = JavaLangString::to_rust_string(jvm, &this.clone()).await?;
 
@@ -493,7 +486,7 @@ impl String {
     }
 
     async fn starts_with(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, prefix: ClassInstanceRef<Self>) -> Result<bool> {
-        tracing::debug!("java.lang.String::startsWith({:?}, {:?})", &this, &prefix);
+        tracing::debug!("java.lang.String::startsWith({this:?}, {prefix:?})");
 
         jvm.invoke_virtual(&this, "startsWith", "(Ljava/lang/String;I)Z", (prefix, 0)).await
     }
@@ -505,7 +498,7 @@ impl String {
         prefix: ClassInstanceRef<Self>,
         offset: i32,
     ) -> Result<bool> {
-        tracing::debug!("java.lang.String::startsWith({:?}, {:?}, {})", &this, &prefix, offset);
+        tracing::debug!("java.lang.String::startsWith({this:?}, {prefix:?}, {offset})");
 
         let this_string = JavaLangString::to_rust_string(jvm, &this.clone())
             .await?
@@ -518,7 +511,7 @@ impl String {
     }
 
     async fn init_empty(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.String::<init>({:?})", &this);
+        tracing::debug!("java.lang.String::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -535,7 +528,7 @@ impl String {
         value: ClassInstanceRef<Array<i8>>,
         charset_name: ClassInstanceRef<Self>,
     ) -> Result<()> {
-        tracing::debug!("java.lang.String::<init>({:?}, {:?}, {:?})", &this, &value, &charset_name);
+        tracing::debug!("java.lang.String::<init>({this:?}, {value:?}, {charset_name:?})");
 
         let count = jvm.array_length(&value).await? as i32;
 
@@ -561,14 +554,7 @@ impl String {
         count: i32,
         charset_name: ClassInstanceRef<Self>,
     ) -> Result<()> {
-        tracing::debug!(
-            "java.lang.String::<init>({:?}, {:?}, {}, {}, {:?})",
-            &this,
-            &value,
-            offset,
-            count,
-            &charset_name
-        );
+        tracing::debug!("java.lang.String::<init>({this:?}, {value:?}, {offset}, {count}, {charset_name:?})");
 
         if charset_name.is_null() {
             return Err(jvm.exception("java/lang/NullPointerException", "charsetName is null").await);
@@ -590,7 +576,7 @@ impl String {
     }
 
     async fn equals_ignore_case(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, other: ClassInstanceRef<Self>) -> Result<bool> {
-        tracing::debug!("java.lang.String::equalsIgnoreCase({:?}, {:?})", &this, &other);
+        tracing::debug!("java.lang.String::equalsIgnoreCase({this:?}, {other:?})");
 
         if other.is_null() {
             return Ok(false);
@@ -608,7 +594,7 @@ impl String {
         this: ClassInstanceRef<Self>,
         charset_name: ClassInstanceRef<Self>,
     ) -> Result<ClassInstanceRef<Array<i8>>> {
-        tracing::debug!("java.lang.String::getBytes({:?}, {:?})", &this, &charset_name);
+        tracing::debug!("java.lang.String::getBytes({this:?}, {charset_name:?})");
 
         if charset_name.is_null() {
             return Err(jvm.exception("java/lang/NullPointerException", "charsetName is null").await);
@@ -626,7 +612,7 @@ impl String {
     }
 
     async fn to_lower_case(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<Self>> {
-        tracing::debug!("java.lang.String::toLowerCase({:?})", &this);
+        tracing::debug!("java.lang.String::toLowerCase({this:?})");
 
         let string = JavaLangString::to_rust_string(jvm, &this).await?;
         let lower = string.to_lowercase();
@@ -641,7 +627,7 @@ impl String {
         old_char: JavaChar,
         new_char: JavaChar,
     ) -> Result<ClassInstanceRef<Self>> {
-        tracing::debug!("java.lang.String::replace({:?}, {}, {})", &this, old_char, new_char);
+        tracing::debug!("java.lang.String::replace({this:?}, {old_char}, {new_char})");
 
         let value = jvm.get_field(&this, "value", "[C").await?;
         let length = jvm.array_length(&value).await?;
@@ -668,15 +654,7 @@ impl String {
         ooffset: i32,
         len: i32,
     ) -> Result<bool> {
-        tracing::debug!(
-            "java.lang.String::regionMatches({:?}, {}, {}, {:?}, {}, {})",
-            &this,
-            ignore_case,
-            toffset,
-            &other,
-            ooffset,
-            len
-        );
+        tracing::debug!("java.lang.String::regionMatches({this:?}, {ignore_case}, {toffset}, {other:?}, {ooffset}, {len})");
 
         if other.is_null() {
             return Err(jvm.exception("java/lang/NullPointerException", "other is null").await);
@@ -714,7 +692,7 @@ impl String {
     }
 
     async fn last_index_of_from(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, ch: i32, from_index: i32) -> Result<i32> {
-        tracing::debug!("java.lang.String::lastIndexOf({:?}, {}, {})", &this, ch, from_index);
+        tracing::debug!("java.lang.String::lastIndexOf({this:?}, {ch}, {from_index})");
 
         if from_index < 0 {
             return Ok(-1);
@@ -730,7 +708,7 @@ impl String {
     }
 
     async fn ends_with(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, suffix: ClassInstanceRef<Self>) -> Result<bool> {
-        tracing::debug!("java.lang.String::endsWith({:?}, {:?})", &this, &suffix);
+        tracing::debug!("java.lang.String::endsWith({this:?}, {suffix:?})");
 
         if suffix.is_null() {
             return Err(jvm.exception("java/lang/NullPointerException", "suffix is null").await);
@@ -743,7 +721,7 @@ impl String {
     }
 
     async fn intern(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<Self>> {
-        tracing::debug!("java.lang.String::intern({:?})", &this);
+        tracing::debug!("java.lang.String::intern({this:?})");
 
         let chars = jvm.get_field(&this, "value", "[C").await?;
         let length = jvm.array_length(&chars).await?;
@@ -755,32 +733,32 @@ impl String {
     }
 
     async fn value_of_boolean(jvm: &Jvm, _: &mut RuntimeContext, value: bool) -> Result<ClassInstanceRef<Self>> {
-        tracing::debug!("java.lang.String::valueOf({})", value);
+        tracing::debug!("java.lang.String::valueOf({value})");
 
         let string = if value { "true" } else { "false" };
         Ok(JavaLangString::from_rust_string(jvm, string).await?.into())
     }
 
     async fn value_of_long(jvm: &Jvm, _: &mut RuntimeContext, value: i64) -> Result<ClassInstanceRef<Self>> {
-        tracing::debug!("java.lang.String::valueOf({})", value);
+        tracing::debug!("java.lang.String::valueOf({value})");
 
         Ok(JavaLangString::from_rust_string(jvm, &value.to_string()).await?.into())
     }
 
     async fn value_of_float(jvm: &Jvm, _: &mut RuntimeContext, value: f32) -> Result<ClassInstanceRef<Self>> {
-        tracing::debug!("java.lang.String::valueOf({})", value);
+        tracing::debug!("java.lang.String::valueOf({value})");
 
         Ok(JavaLangString::from_rust_string(jvm, &value.to_string()).await?.into())
     }
 
     async fn value_of_double(jvm: &Jvm, _: &mut RuntimeContext, value: f64) -> Result<ClassInstanceRef<Self>> {
-        tracing::debug!("java.lang.String::valueOf({})", value);
+        tracing::debug!("java.lang.String::valueOf({value})");
 
         Ok(JavaLangString::from_rust_string(jvm, &value.to_string()).await?.into())
     }
 
     async fn value_of_char_array(jvm: &Jvm, _: &mut RuntimeContext, value: ClassInstanceRef<Array<JavaChar>>) -> Result<ClassInstanceRef<Self>> {
-        tracing::debug!("java.lang.String::valueOf({:?})", &value);
+        tracing::debug!("java.lang.String::valueOf({value:?})");
 
         let new_string = jvm.new_class("java/lang/String", "([C)V", (value,)).await?;
 
@@ -794,7 +772,7 @@ impl String {
         offset: i32,
         count: i32,
     ) -> Result<ClassInstanceRef<Self>> {
-        tracing::debug!("java.lang.String::valueOf({:?}, {}, {})", &value, offset, count);
+        tracing::debug!("java.lang.String::valueOf({value:?}, {offset}, {count})");
 
         let new_string = jvm.new_class("java/lang/String", "([CII)V", (value, offset, count)).await?;
 

--- a/java_runtime/src/classes/java/lang/string_buffer.rs
+++ b/java_runtime/src/classes/java/lang/string_buffer.rs
@@ -57,7 +57,7 @@ impl StringBuffer {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.StringBuffer::<init>({:?})", &this);
+        tracing::debug!("java.lang.StringBuffer::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/StringBuffer", "<init>", "(I)V", (16,)).await?;
 
@@ -65,7 +65,7 @@ impl StringBuffer {
     }
 
     async fn init_with_buffer_length(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, length: i32) -> Result<()> {
-        tracing::debug!("java.lang.StringBuffer::<init>({:?}, {:?})", &this, length);
+        tracing::debug!("java.lang.StringBuffer::<init>({this:?}, {length:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -77,7 +77,7 @@ impl StringBuffer {
     }
 
     async fn init_with_string(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, string: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.lang.StringBuffer::<init>({:?}, {:?})", &this, &string,);
+        tracing::debug!("java.lang.StringBuffer::<init>({this:?}, {string:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -96,7 +96,7 @@ impl StringBuffer {
         mut this: ClassInstanceRef<Self>,
         string: ClassInstanceRef<String>,
     ) -> Result<ClassInstanceRef<Self>> {
-        tracing::debug!("java.lang.StringBuffer::append({:?}, {:?})", &this, &string,);
+        tracing::debug!("java.lang.StringBuffer::append({this:?}, {string:?})");
 
         let string = if string.is_null() {
             "null".into()
@@ -115,7 +115,7 @@ impl StringBuffer {
         mut this: ClassInstanceRef<Self>,
         object: ClassInstanceRef<Object>,
     ) -> Result<ClassInstanceRef<Self>> {
-        tracing::debug!("java.lang.StringBuffer::append({:?}, {:?})", &this, &object,);
+        tracing::debug!("java.lang.StringBuffer::append({this:?}, {object:?})");
 
         let string = if object.is_null() {
             "null".into()
@@ -130,7 +130,7 @@ impl StringBuffer {
     }
 
     async fn append_integer(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, value: i32) -> Result<ClassInstanceRef<Self>> {
-        tracing::debug!("java.lang.StringBuffer::append({:?}, {:?})", &this, value);
+        tracing::debug!("java.lang.StringBuffer::append({this:?}, {value:?})");
 
         let digits = value.to_string();
 
@@ -140,7 +140,7 @@ impl StringBuffer {
     }
 
     async fn append_boolean(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, value: bool) -> Result<ClassInstanceRef<Self>> {
-        tracing::debug!("java.lang.StringBuffer::append({:?}, {:?})", &this, value);
+        tracing::debug!("java.lang.StringBuffer::append({this:?}, {value:?})");
 
         let value = value.to_string();
 
@@ -150,7 +150,7 @@ impl StringBuffer {
     }
 
     async fn append_long(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, value: i64) -> Result<ClassInstanceRef<Self>> {
-        tracing::debug!("java.lang.StringBuffer::append({:?}, {:?})", &this, value);
+        tracing::debug!("java.lang.StringBuffer::append({this:?}, {value:?})");
 
         let digits = value.to_string();
 
@@ -160,7 +160,7 @@ impl StringBuffer {
     }
 
     async fn append_character(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, value: u16) -> Result<ClassInstanceRef<Self>> {
-        tracing::debug!("java.lang.StringBuffer::append({:?}, {:?})", &this, value);
+        tracing::debug!("java.lang.StringBuffer::append({this:?}, {value:?})");
 
         let value = RustString::from_utf16(&[value]).unwrap();
 
@@ -177,7 +177,7 @@ impl StringBuffer {
         offset: i32,
         length: i32,
     ) -> Result<ClassInstanceRef<Self>> {
-        tracing::debug!("java.lang.StringBuffer::append({:?}, {:?}, {:?}, {:?})", &this, &array, offset, length);
+        tracing::debug!("java.lang.StringBuffer::append({this:?}, {array:?}, {offset:?}, {length:?})");
 
         let value: Vec<JavaChar> = jvm.load_array(&array, offset as _, length as _).await?;
         let string = RustString::from_utf16(&value).unwrap();
@@ -210,7 +210,7 @@ impl StringBuffer {
     }
 
     async fn to_string(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<String>> {
-        tracing::debug!("java.lang.StringBuffer::toString({:?})", &this);
+        tracing::debug!("java.lang.StringBuffer::toString({this:?})");
 
         let java_value: ClassInstanceRef<Array<JavaChar>> = jvm.get_field(&this, "value", "[C").await?;
         let count: i32 = jvm.get_field(&this, "count", "I").await?;
@@ -252,7 +252,7 @@ impl StringBuffer {
     }
 
     async fn set_length(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, length: i32) -> Result<()> {
-        tracing::debug!("java.lang.StringBuffer::setLength({:?}, {:?})", &this, length);
+        tracing::debug!("java.lang.StringBuffer::setLength({this:?}, {length:?})");
 
         jvm.put_field(&mut this, "count", "I", length).await?;
 
@@ -260,7 +260,7 @@ impl StringBuffer {
     }
 
     async fn length(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<i32> {
-        tracing::debug!("java.lang.StringBuffer::length({:?})", &this);
+        tracing::debug!("java.lang.StringBuffer::length({this:?})");
 
         let count: i32 = jvm.get_field(&this, "count", "I").await?;
 
@@ -268,7 +268,7 @@ impl StringBuffer {
     }
 
     async fn char_at(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, index: i32) -> Result<JavaChar> {
-        tracing::debug!("java.lang.StringBuffer::charAt({:?}, {:?})", &this, index);
+        tracing::debug!("java.lang.StringBuffer::charAt({this:?}, {index:?})");
 
         let java_value: ClassInstanceRef<Array<JavaChar>> = jvm.get_field(&this, "value", "[C").await?;
         let char_at: JavaChar = jvm.load_array(&java_value, index as _, 1).await?.into_iter().next().unwrap();

--- a/java_runtime/src/classes/java/lang/string_index_out_of_bounds_exception.rs
+++ b/java_runtime/src/classes/java/lang/string_index_out_of_bounds_exception.rs
@@ -24,7 +24,7 @@ impl StringIndexOutOfBoundsException {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.StringIndexOutOfBoundsException::<init>({:?})", &this);
+        tracing::debug!("java.lang.StringIndexOutOfBoundsException::<init>({this:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/IndexOutOfBoundsException", "<init>", "()V", ())
@@ -34,7 +34,7 @@ impl StringIndexOutOfBoundsException {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.lang.StringIndexOutOfBoundsException::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.lang.StringIndexOutOfBoundsException::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(

--- a/java_runtime/src/classes/java/lang/system.rs
+++ b/java_runtime/src/classes/java/lang/system.rs
@@ -111,14 +111,7 @@ impl System {
         dest_pos: i32,
         length: i32,
     ) -> Result<()> {
-        tracing::debug!(
-            "java.lang.System::arraycopy({:?}, {}, {:?}, {}, {})",
-            &src,
-            src_pos,
-            &dest,
-            dest_pos,
-            length
-        );
+        tracing::debug!("java.lang.System::arraycopy({src:?}, {src_pos}, {dest:?}, {dest_pos}, {length})");
 
         // TODO i think we can make it faster
         let src: Vec<JavaValue> = jvm.load_array(&src, src_pos as _, length as _).await?;
@@ -128,7 +121,7 @@ impl System {
     }
 
     async fn get_property(jvm: &Jvm, _: &mut RuntimeContext, key: ClassInstanceRef<String>) -> Result<ClassInstanceRef<String>> {
-        tracing::debug!("java.lang.System::getProperty({:?})", key);
+        tracing::debug!("java.lang.System::getProperty({key:?})");
 
         let props = jvm.get_static_field("java/lang/System", "props", "Ljava/util/Properties;").await?;
         let value = jvm
@@ -144,7 +137,7 @@ impl System {
         key: ClassInstanceRef<String>,
         value: ClassInstanceRef<String>,
     ) -> Result<ClassInstanceRef<String>> {
-        tracing::debug!("java.lang.System::setProperty({:?}, {:?})", key, value);
+        tracing::debug!("java.lang.System::setProperty({key:?}, {value:?})");
 
         let props = jvm.get_static_field("java/lang/System", "props", "Ljava/util/Properties;").await?;
         let value = jvm

--- a/java_runtime/src/classes/java/lang/thread.rs
+++ b/java_runtime/src/classes/java/lang/thread.rs
@@ -45,7 +45,7 @@ impl Thread {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.Thread::<init>({:?})", &this);
+        tracing::debug!("java.lang.Thread::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -58,7 +58,7 @@ impl Thread {
         mut this: ClassInstanceRef<Self>,
         target: ClassInstanceRef<Runnable>,
     ) -> Result<()> {
-        tracing::debug!("java.lang.Thread::<init>({:?}, {:?})", &this, &target);
+        tracing::debug!("java.lang.Thread::<init>({this:?}, {target:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -68,7 +68,7 @@ impl Thread {
     }
 
     async fn init_internal(jvm: &Jvm, context: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, internal: bool) -> Result<()> {
-        tracing::debug!("java.lang.Thread::<init>({:?}, {:?})", &this, internal);
+        tracing::debug!("java.lang.Thread::<init>({this:?}, {internal:?})");
 
         let id = context.current_task_id();
         jvm.put_field(&mut this, "id", "J", id as i64).await?;
@@ -77,7 +77,7 @@ impl Thread {
     }
 
     async fn start(jvm: &Jvm, context: &mut RuntimeContext, mut this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.Thread::start({:?})", &this);
+        tracing::debug!("java.lang.Thread::start({this:?})");
 
         struct ThreadStartProxy {
             jvm: Jvm,
@@ -151,7 +151,7 @@ impl Thread {
     }
 
     async fn run(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.Thread::run({:?})", &this);
+        tracing::debug!("java.lang.Thread::run({this:?})");
 
         let target: ClassInstanceRef<Runnable> = jvm.get_field(&this, "target", "Ljava/lang/Runnable;").await?;
         if !target.is_null() {
@@ -162,7 +162,7 @@ impl Thread {
     }
 
     async fn join(jvm: &Jvm, _context: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.Thread::join({:?})", &this);
+        tracing::debug!("java.lang.Thread::join({this:?})");
 
         loop {
             let listener = jvm.object_listen(&this);
@@ -175,13 +175,13 @@ impl Thread {
     }
 
     async fn is_alive(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<bool> {
-        tracing::debug!("java.lang.Thread::isAlive({:?})", &this);
+        tracing::debug!("java.lang.Thread::isAlive({this:?})");
         let alive: bool = jvm.get_field(&this, "alive", "Z").await?;
         Ok(alive)
     }
 
     async fn sleep(_: &Jvm, context: &mut RuntimeContext, duration: i64) -> Result<()> {
-        tracing::debug!("java.lang.Thread::sleep({:?})", duration);
+        tracing::debug!("java.lang.Thread::sleep({duration:?})");
 
         context.sleep(Duration::from_millis(duration as _)).await;
 
@@ -196,7 +196,7 @@ impl Thread {
     }
 
     async fn set_priority(_: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Thread>, new_priority: i32) -> Result<()> {
-        tracing::warn!("stub java.lang.Thread::setPriority({:?}, {:?})", &this, new_priority);
+        tracing::warn!("stub java.lang.Thread::setPriority({this:?}, {new_priority:?})");
 
         Ok(())
     }

--- a/java_runtime/src/classes/java/lang/throwable.rs
+++ b/java_runtime/src/classes/java/lang/throwable.rs
@@ -68,7 +68,7 @@ impl Throwable {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.Throwable::<init>({:?})", &this);
+        tracing::debug!("java.lang.Throwable::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -78,7 +78,7 @@ impl Throwable {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.lang.Throwable::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.lang.Throwable::<init>({this:?}, {message:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -90,7 +90,7 @@ impl Throwable {
     }
 
     async fn init_with_cause(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, cause: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.Throwable::<init>({:?}, {:?})", &this, &cause);
+        tracing::debug!("java.lang.Throwable::<init>({this:?}, {cause:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -114,7 +114,7 @@ impl Throwable {
         message: ClassInstanceRef<String>,
         cause: ClassInstanceRef<Self>,
     ) -> Result<()> {
-        tracing::debug!("java.lang.Throwable::<init>({:?}, {:?}, {:?})", &this, &message, &cause);
+        tracing::debug!("java.lang.Throwable::<init>({this:?}, {message:?}, {cause:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -127,7 +127,7 @@ impl Throwable {
     }
 
     async fn get_cause(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<Self>> {
-        tracing::debug!("java.lang.Throwable::getCause({:?})", &this);
+        tracing::debug!("java.lang.Throwable::getCause({this:?})");
 
         jvm.get_field(&this, "cause", "Ljava/lang/Throwable;").await
     }
@@ -138,7 +138,7 @@ impl Throwable {
         mut this: ClassInstanceRef<Self>,
         cause: ClassInstanceRef<Self>,
     ) -> Result<ClassInstanceRef<Self>> {
-        tracing::debug!("java.lang.Throwable::initCause({:?}, {:?})", &this, &cause);
+        tracing::debug!("java.lang.Throwable::initCause({this:?}, {cause:?})");
 
         jvm.put_field(&mut this, "cause", "Ljava/lang/Throwable;", cause).await?;
 
@@ -146,7 +146,7 @@ impl Throwable {
     }
 
     async fn fill_in_stack_trace(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<Self>> {
-        tracing::debug!("java.lang.Throwable::fillInStackTrace({:?})", &this);
+        tracing::debug!("java.lang.Throwable::fillInStackTrace({this:?})");
 
         let stack_trace = jvm.stack_trace();
         let mut stack_trace_array = jvm.instantiate_array("Ljava/lang/String;", stack_trace.len()).await?;
@@ -160,7 +160,7 @@ impl Throwable {
     }
 
     async fn print_stack_trace(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.Throwable::printStackTrace({:?})", &this);
+        tracing::debug!("java.lang.Throwable::printStackTrace({this:?})");
 
         let err: ClassInstanceRef<PrintStream> = jvm.get_static_field("java/lang/System", "err", "Ljava/io/PrintStream;").await?;
 
@@ -175,7 +175,7 @@ impl Throwable {
         this: ClassInstanceRef<Self>,
         stream: ClassInstanceRef<PrintStream>,
     ) -> Result<()> {
-        tracing::debug!("java.lang.Throwable::printStackTrace({:?}, {:?})", &this, &stream);
+        tracing::debug!("java.lang.Throwable::printStackTrace({this:?}, {stream:?})");
 
         Self::do_print_stack_trace(jvm, this, stream.into()).await?;
 
@@ -188,7 +188,7 @@ impl Throwable {
         this: ClassInstanceRef<Self>,
         writer: ClassInstanceRef<PrintWriter>,
     ) -> Result<()> {
-        tracing::debug!("java.lang.Throwable::printStackTrace({:?}, {:?})", &this, &writer);
+        tracing::debug!("java.lang.Throwable::printStackTrace({this:?}, {writer:?})");
 
         Self::do_print_stack_trace(jvm, this, writer.into()).await?;
 
@@ -196,7 +196,7 @@ impl Throwable {
     }
 
     async fn to_string(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<String>> {
-        tracing::debug!("java.lang.Throwable::toString({:?})", &this);
+        tracing::debug!("java.lang.Throwable::toString({this:?})");
 
         let class = jvm.invoke_virtual(&this, "getClass", "()Ljava/lang/Class;", ()).await?;
         let class_name = jvm.invoke_virtual(&class, "getName", "()Ljava/lang/String;", ()).await?;

--- a/java_runtime/src/classes/java/lang/unsupported_operation_exception.rs
+++ b/java_runtime/src/classes/java/lang/unsupported_operation_exception.rs
@@ -24,7 +24,7 @@ impl UnsupportedOperationException {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.UnsupportedOperationException::<init>({:?})", &this);
+        tracing::debug!("java.lang.UnsupportedOperationException::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/RuntimeException", "<init>", "()V", ()).await?;
 
@@ -32,7 +32,7 @@ impl UnsupportedOperationException {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.lang.UnsupportedOperationException::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.lang.UnsupportedOperationException::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/RuntimeException", "<init>", "(Ljava/lang/String;)V", (message,))

--- a/java_runtime/src/classes/java/net/jar_url_connection.rs
+++ b/java_runtime/src/classes/java/net/jar_url_connection.rs
@@ -40,7 +40,7 @@ impl JarURLConnection {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, url: ClassInstanceRef<URL>) -> Result<()> {
-        tracing::debug!("java.net.JarURLConnection::<init>({:?}, {:?})", &this, &url,);
+        tracing::debug!("java.net.JarURLConnection::<init>({this:?}, {url:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/net/URLConnection", "<init>", "(Ljava/net/URL;)V", (url.clone(),))
@@ -61,7 +61,7 @@ impl JarURLConnection {
     }
 
     async fn get_entry_name(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<String>> {
-        tracing::debug!("java.net.JarURLConnection::getEntryName({:?})", &this);
+        tracing::debug!("java.net.JarURLConnection::getEntryName({this:?})");
 
         let entry = jvm.get_field(&this, "entry", "Ljava/lang/String;").await?;
 
@@ -69,7 +69,7 @@ impl JarURLConnection {
     }
 
     async fn get_jar_file_url(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<URL>> {
-        tracing::debug!("java.net.JarURLConnection::getJarFileURL({:?})", &this);
+        tracing::debug!("java.net.JarURLConnection::getJarFileURL({this:?})");
 
         let file_url = jvm.get_field(&this, "fileUrl", "Ljava/net/URL;").await?;
 
@@ -77,7 +77,7 @@ impl JarURLConnection {
     }
 
     async fn get_jar_entry(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<URL>> {
-        tracing::debug!("java.net.JarURLConnection::getJarEntry({:?})", &this);
+        tracing::debug!("java.net.JarURLConnection::getJarEntry({this:?})");
 
         let jar_file = jvm.invoke_virtual(&this, "getJarFile", "()Ljava/util/jar/JarFile;", ()).await?;
         let entry_name: ClassInstanceRef<String> = jvm.invoke_virtual(&this, "getEntryName", "()Ljava/lang/String;", ()).await?;
@@ -90,7 +90,7 @@ impl JarURLConnection {
     }
 
     async fn get_main_attributes(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<Attributes>> {
-        tracing::debug!("java.net.JarURLConnection::getMainAttributes({:?})", &this);
+        tracing::debug!("java.net.JarURLConnection::getMainAttributes({this:?})");
 
         let jar_file = jvm.invoke_virtual(&this, "getJarFile", "()Ljava/util/jar/JarFile;", ()).await?;
         let manifest = jvm.invoke_virtual(&jar_file, "getManifest", "()Ljava/util/jar/Manifest;", ()).await?;

--- a/java_runtime/src/classes/java/net/malformed_url_exception.rs
+++ b/java_runtime/src/classes/java/net/malformed_url_exception.rs
@@ -24,7 +24,7 @@ impl MalformedURLException {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.net.MalformedURLException::<init>({:?})", &this);
+        tracing::debug!("java.net.MalformedURLException::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/io/IOException", "<init>", "()V", ()).await?;
 
@@ -32,7 +32,7 @@ impl MalformedURLException {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.net.MalformedURLException::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.net.MalformedURLException::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/io/IOException", "<init>", "(Ljava/lang/String;)V", (message,))

--- a/java_runtime/src/classes/java/net/unknown_service_exception.rs
+++ b/java_runtime/src/classes/java/net/unknown_service_exception.rs
@@ -24,7 +24,7 @@ impl UnknownServiceException {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.io.UnknownServiceException::<init>({:?})", &this);
+        tracing::debug!("java.io.UnknownServiceException::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/io/IOException", "<init>", "()V", ()).await?;
 
@@ -32,7 +32,7 @@ impl UnknownServiceException {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.io.UnknownServiceException::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.io.UnknownServiceException::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/io/IOException", "<init>", "(Ljava/lang/String;)V", (message,))

--- a/java_runtime/src/classes/java/net/url.rs
+++ b/java_runtime/src/classes/java/net/url.rs
@@ -72,7 +72,7 @@ impl URL {
     }
 
     async fn init_with_spec(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, spec: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.net.URL::<init>({:?}, {:?})", &this, &spec);
+        tracing::debug!("java.net.URL::<init>({this:?}, {spec:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/net/URL", "<init>", "(Ljava/net/URL;Ljava/lang/String;)V", (None, spec))
@@ -88,7 +88,7 @@ impl URL {
         context: ClassInstanceRef<URL>,
         spec: ClassInstanceRef<String>,
     ) -> Result<()> {
-        tracing::debug!("java.net.URL::<init>({:?}, {:?}, {:?})", &this, &context, &spec);
+        tracing::debug!("java.net.URL::<init>({this:?}, {context:?}, {spec:?})");
 
         let _: () = jvm
             .invoke_special(
@@ -111,7 +111,7 @@ impl URL {
         spec: ClassInstanceRef<String>,
         handler: ClassInstanceRef<URLStreamHandler>,
     ) -> Result<()> {
-        tracing::debug!("java.net.URL::<init>({:?}, {:?}, {:?}, {:?})", &this, &context, &spec, &handler);
+        tracing::debug!("java.net.URL::<init>({this:?}, {context:?}, {spec:?}, {handler:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -144,7 +144,7 @@ impl URL {
         host: ClassInstanceRef<String>,
         file: ClassInstanceRef<String>,
     ) -> Result<()> {
-        tracing::debug!("java.net.URL::<init>({:?}, {:?}, {:?}, {:?})", &this, &protocol, &host, &file);
+        tracing::debug!("java.net.URL::<init>({this:?}, {protocol:?}, {host:?}, {file:?})");
 
         let _: () = jvm
             .invoke_special(
@@ -170,15 +170,7 @@ impl URL {
         file: ClassInstanceRef<String>,
         handler: ClassInstanceRef<URLStreamHandler>,
     ) -> Result<()> {
-        tracing::debug!(
-            "java.net.URL::<init>({:?}, {:?}, {:?}, {:?}, {:?}, {:?})",
-            &this,
-            &protocol,
-            &host,
-            &port,
-            &file,
-            &handler
-        );
+        tracing::debug!("java.net.URL::<init>({this:?}, {protocol:?}, {host:?}, {port:?}, {file:?}, {handler:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -215,15 +207,7 @@ impl URL {
         file: ClassInstanceRef<String>,
         r#ref: ClassInstanceRef<String>,
     ) -> Result<()> {
-        tracing::debug!(
-            "java.net.URL::set({:?}, {:?}, {:?}, {:?}, {:?}, {:?})",
-            &this,
-            &protocol,
-            &host,
-            &port,
-            &file,
-            &r#ref
-        );
+        tracing::debug!("java.net.URL::set({this:?}, {protocol:?}, {host:?}, {port:?}, {file:?}, {:?})", &r#ref);
 
         jvm.put_field(&mut this, "protocol", "Ljava/lang/String;", protocol).await?;
         jvm.put_field(&mut this, "host", "Ljava/lang/String;", host).await?;
@@ -234,7 +218,7 @@ impl URL {
     }
 
     async fn open_connection(jvm: &Jvm, _runtime: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<URLConnection>> {
-        tracing::debug!("java.net.URL::openConnection({:?})", &this);
+        tracing::debug!("java.net.URL::openConnection({this:?})");
 
         let handler = jvm.get_field(&this, "handler", "Ljava/net/URLStreamHandler;").await?;
         let connection = jvm
@@ -245,7 +229,7 @@ impl URL {
     }
 
     async fn open_stream(jvm: &Jvm, _runtime: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<InputStream>> {
-        tracing::debug!("java.net.URL::openStream({:?})", &this);
+        tracing::debug!("java.net.URL::openStream({this:?})");
 
         let connection = jvm.invoke_virtual(&this, "openConnection", "()Ljava/net/URLConnection;", ()).await?;
 
@@ -255,7 +239,7 @@ impl URL {
     }
 
     async fn get_port(jvm: &Jvm, _runtime: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<i32> {
-        tracing::debug!("java.net.URL::getPort({:?})", &this);
+        tracing::debug!("java.net.URL::getPort({this:?})");
 
         let port = jvm.get_field(&this, "port", "I").await?;
 
@@ -263,7 +247,7 @@ impl URL {
     }
 
     async fn get_protocol(jvm: &Jvm, _runtime: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<String>> {
-        tracing::debug!("java.net.URL::getProtocol({:?})", &this);
+        tracing::debug!("java.net.URL::getProtocol({this:?})");
 
         let protocol = jvm.get_field(&this, "protocol", "Ljava/lang/String;").await?;
 
@@ -271,7 +255,7 @@ impl URL {
     }
 
     async fn get_host(jvm: &Jvm, _runtime: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<String>> {
-        tracing::debug!("java.net.URL::getHost({:?})", &this);
+        tracing::debug!("java.net.URL::getHost({this:?})");
 
         let host = jvm.get_field(&this, "host", "Ljava/lang/String;").await?;
 
@@ -279,7 +263,7 @@ impl URL {
     }
 
     async fn get_file(jvm: &Jvm, _runtime: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<String>> {
-        tracing::debug!("java.net.URL::getFile({:?})", &this);
+        tracing::debug!("java.net.URL::getFile({this:?})");
 
         let file = jvm.get_field(&this, "file", "Ljava/lang/String;").await?;
 

--- a/java_runtime/src/classes/java/net/url_class_loader.rs
+++ b/java_runtime/src/classes/java/net/url_class_loader.rs
@@ -46,7 +46,7 @@ impl URLClassLoader {
         urls: ClassInstanceRef<Array<URL>>,
         parent: ClassInstanceRef<ClassLoader>,
     ) -> Result<()> {
-        tracing::debug!("java.net.URLClassLoader::<init>({:?}, {:?}, {:?})", &this, &urls, &parent);
+        tracing::debug!("java.net.URLClassLoader::<init>({this:?}, {urls:?}, {parent:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/ClassLoader", "<init>", "(Ljava/lang/ClassLoader;)V", (parent,))
@@ -63,7 +63,7 @@ impl URLClassLoader {
         this: ClassInstanceRef<Self>,
         name: ClassInstanceRef<String>,
     ) -> Result<ClassInstanceRef<Class>> {
-        tracing::debug!("java.net.URLClassLoader::findClass({:?}, {:?})", &this, name);
+        tracing::debug!("java.net.URLClassLoader::findClass({this:?}, {name:?})");
 
         let name_str = JavaLangString::to_rust_string(jvm, &name).await?;
 
@@ -120,7 +120,7 @@ impl URLClassLoader {
         this: ClassInstanceRef<Self>,
         name: ClassInstanceRef<String>,
     ) -> Result<ClassInstanceRef<URL>> {
-        tracing::debug!("java.net.URLClassLoader::findResource({:?}, {:?})", &this, name);
+        tracing::debug!("java.net.URLClassLoader::findResource({this:?}, {name:?})");
 
         let name_str = JavaLangString::to_rust_string(jvm, &name).await?;
 

--- a/java_runtime/src/classes/java/net/url_connection.rs
+++ b/java_runtime/src/classes/java/net/url_connection.rs
@@ -27,7 +27,7 @@ impl URLConnection {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, url: ClassInstanceRef<URL>) -> Result<()> {
-        tracing::debug!("java.net.URL::<init>({:?}, {:?})", &this, &url,);
+        tracing::debug!("java.net.URL::<init>({this:?}, {url:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -35,7 +35,7 @@ impl URLConnection {
     }
 
     async fn get_input_stream(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<InputStream>> {
-        tracing::debug!("java.net.URL::getInputStream({:?})", &this);
+        tracing::debug!("java.net.URL::getInputStream({this:?})");
 
         Err(jvm.exception("java/io/UnknownServiceException", "unsupported").await)
     }

--- a/java_runtime/src/classes/java/net/url_connection.rs
+++ b/java_runtime/src/classes/java/net/url_connection.rs
@@ -27,7 +27,7 @@ impl URLConnection {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, url: ClassInstanceRef<URL>) -> Result<()> {
-        tracing::debug!("java.net.URL::<init>({this:?}, {url:?})");
+        tracing::debug!("java.net.URLConnection::<init>({this:?}, {url:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -35,7 +35,7 @@ impl URLConnection {
     }
 
     async fn get_input_stream(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<InputStream>> {
-        tracing::debug!("java.net.URL::getInputStream({this:?})");
+        tracing::debug!("java.net.URLConnection::getInputStream({this:?})");
 
         Err(jvm.exception("java/io/UnknownServiceException", "unsupported").await)
     }

--- a/java_runtime/src/classes/java/net/url_stream_handler.rs
+++ b/java_runtime/src/classes/java/net/url_stream_handler.rs
@@ -37,7 +37,7 @@ impl URLStreamHandler {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.net.URLStreamHandler::<init>({:?})", &this);
+        tracing::debug!("java.net.URLStreamHandler::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -57,14 +57,8 @@ impl URLStreamHandler {
         r#ref: ClassInstanceRef<String>,
     ) -> Result<()> {
         tracing::debug!(
-            "java.net.URLStreamHandler::setURL({:?}, {:?}, {:?}, {:?}, {:?}, {:?}, {:?})",
-            &this,
-            &url,
-            &protocol,
-            &host,
-            &port,
-            &file,
-            &r#ref,
+            "java.net.URLStreamHandler::setURL({this:?}, {url:?}, {protocol:?}, {host:?}, {port:?}, {file:?}, {:?})",
+            &r#ref
         );
 
         let _: () = jvm
@@ -88,14 +82,7 @@ impl URLStreamHandler {
         start: i32,
         limit: i32,
     ) -> Result<()> {
-        tracing::debug!(
-            "java.net.URLStreamHandler::parseURL({:?}, {:?}, {:?}, {:?}, {:?})",
-            &this,
-            &url,
-            &spec,
-            &start,
-            &limit
-        );
+        tracing::debug!("java.net.URLStreamHandler::parseURL({this:?}, {url:?}, {spec:?}, {start:?}, {limit:?})");
 
         let spec_str = JavaLangString::to_rust_string(jvm, &spec).await?;
 

--- a/java_runtime/src/classes/java/util/abstract_collection.rs
+++ b/java_runtime/src/classes/java/util/abstract_collection.rs
@@ -22,7 +22,7 @@ impl AbstractCollection {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.util.AbstractCollection::<init>({:?})", &this);
+        tracing::debug!("java.util.AbstractCollection::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 

--- a/java_runtime/src/classes/java/util/abstract_list.rs
+++ b/java_runtime/src/classes/java/util/abstract_list.rs
@@ -22,7 +22,7 @@ impl AbstractList {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.util.AbstractList::<init>({:?})", &this);
+        tracing::debug!("java.util.AbstractList::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/util/AbstractCollection", "<init>", "()V", ()).await?;
 

--- a/java_runtime/src/classes/java/util/calendar.rs
+++ b/java_runtime/src/classes/java/util/calendar.rs
@@ -55,7 +55,7 @@ impl Calendar {
         _: &mut RuntimeContext,
         time_zone: ClassInstanceRef<TimeZone>,
     ) -> Result<ClassInstanceRef<Calendar>> {
-        tracing::debug!("java.util.Calendar::getInstance({:?})", &time_zone);
+        tracing::debug!("java.util.Calendar::getInstance({time_zone:?})");
 
         let instance = jvm
             .new_class("java/util/GregorianCalendar", "(Ljava/util/TimeZone;)V", (time_zone,))
@@ -65,7 +65,7 @@ impl Calendar {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.util.Calendar::<init>({:?})", &this);
+        tracing::debug!("java.util.Calendar::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -77,7 +77,7 @@ impl Calendar {
     }
 
     async fn set_time(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, date: ClassInstanceRef<Date>) -> Result<()> {
-        tracing::debug!("java.util.Calendar::setTime({:?}, {:?})", &this, &date);
+        tracing::debug!("java.util.Calendar::setTime({this:?}, {date:?})");
 
         let time: i64 = jvm.invoke_virtual(&date, "getTime", "()J", ()).await?;
         jvm.put_field(&mut this, "time", "J", time).await?;
@@ -88,7 +88,7 @@ impl Calendar {
     }
 
     async fn get_time(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<Date>> {
-        tracing::debug!("java.util.Calendar::getTime({:?})", &this);
+        tracing::debug!("java.util.Calendar::getTime({this:?})");
 
         let time: i64 = jvm.get_field(&this, "time", "J").await?;
         let date = jvm.new_class("java/util/Date", "(J)V", (time,)).await?;
@@ -97,7 +97,7 @@ impl Calendar {
     }
 
     async fn set(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, field: i32, value: i32) -> Result<()> {
-        tracing::debug!("java.util.Calendar::set({:?}, {:?}, {:?})", &this, field, value);
+        tracing::debug!("java.util.Calendar::set({this:?}, {field:?}, {value:?})");
 
         let mut fields = jvm.get_field(&this, "fields", "[I").await?;
         jvm.store_array(&mut fields, field as usize, vec![value]).await?;
@@ -109,7 +109,7 @@ impl Calendar {
     }
 
     async fn get(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, field: i32) -> Result<i32> {
-        tracing::debug!("java.util.Calendar::get({:?}, {:?})", &this, field);
+        tracing::debug!("java.util.Calendar::get({this:?}, {field:?})");
 
         let fields = jvm.get_field(&this, "fields", "[I").await?;
         let value = jvm.load_array(&fields, field as usize, 1).await?[0];

--- a/java_runtime/src/classes/java/util/date.rs
+++ b/java_runtime/src/classes/java/util/date.rs
@@ -26,7 +26,7 @@ impl Date {
     }
 
     async fn init(jvm: &Jvm, context: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.util.Date::<init>({:?})", &this);
+        tracing::debug!("java.util.Date::<init>({this:?})");
 
         let now: u64 = context.now();
 
@@ -36,7 +36,7 @@ impl Date {
     }
 
     async fn init_with_time(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, time: i64) -> Result<()> {
-        tracing::debug!("java.util.Date::<init>({:?}, {:?})", &this, time);
+        tracing::debug!("java.util.Date::<init>({this:?}, {time:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -46,7 +46,7 @@ impl Date {
     }
 
     async fn get_time(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<i64> {
-        tracing::debug!("java.util.Date::getTime({:?})", &this);
+        tracing::debug!("java.util.Date::getTime({this:?})");
 
         let time = jvm.get_field(&this, "value", "J").await?;
 
@@ -54,7 +54,7 @@ impl Date {
     }
 
     async fn set_time(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, time: i64) -> Result<()> {
-        tracing::debug!("java.util.Date::setTime({:?}, {:?})", &this, time);
+        tracing::debug!("java.util.Date::setTime({this:?}, {time:?})");
 
         jvm.put_field(&mut this, "value", "J", time).await?;
 

--- a/java_runtime/src/classes/java/util/dictionary.rs
+++ b/java_runtime/src/classes/java/util/dictionary.rs
@@ -22,7 +22,7 @@ impl Dictionary {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.util.Dictionary::<init>({:?})", &this);
+        tracing::debug!("java.util.Dictionary::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 

--- a/java_runtime/src/classes/java/util/empty_stack_exception.rs
+++ b/java_runtime/src/classes/java/util/empty_stack_exception.rs
@@ -24,7 +24,7 @@ impl EmptyStackException {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.lang.EmptyStackException::<init>({:?})", &this);
+        tracing::debug!("java.lang.EmptyStackException::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/RuntimeException", "<init>", "()V", ()).await?;
 
@@ -32,7 +32,7 @@ impl EmptyStackException {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.lang.EmptyStackException::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.lang.EmptyStackException::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/RuntimeException", "<init>", "(Ljava/lang/String;)V", (message,))

--- a/java_runtime/src/classes/java/util/gregorian_calendar.rs
+++ b/java_runtime/src/classes/java/util/gregorian_calendar.rs
@@ -49,7 +49,7 @@ impl GregorianCalendar {
     }
 
     async fn compute_time(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.util.GregorianCalendar::computeTime({:?})", &this);
+        tracing::debug!("java.util.GregorianCalendar::computeTime({this:?})");
 
         // fields -> time
 
@@ -90,7 +90,7 @@ impl GregorianCalendar {
     }
 
     async fn compute_fields(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.util.GregorianCalendar::computeFields({:?})", &this);
+        tracing::debug!("java.util.GregorianCalendar::computeFields({this:?})");
 
         // time -> fields
 

--- a/java_runtime/src/classes/java/util/jar/attributes.rs
+++ b/java_runtime/src/classes/java/util/jar/attributes.rs
@@ -30,7 +30,7 @@ impl Attributes {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.util.jar.Manifest::<init>({this:?})");
+        tracing::debug!("java.util.jar.Attributes::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 

--- a/java_runtime/src/classes/java/util/jar/attributes.rs
+++ b/java_runtime/src/classes/java/util/jar/attributes.rs
@@ -30,7 +30,7 @@ impl Attributes {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.util.jar.Manifest::<init>({:?})", &this);
+        tracing::debug!("java.util.jar.Manifest::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -48,7 +48,7 @@ impl Attributes {
         name: ClassInstanceRef<String>,
         value: ClassInstanceRef<String>,
     ) -> Result<ClassInstanceRef<String>> {
-        tracing::debug!("java.util.jar.Attributes::putValue({:?}, {:?}, {:?})", &this, &name, &value);
+        tracing::debug!("java.util.jar.Attributes::putValue({this:?}, {name:?}, {value:?})");
 
         // TODO we should store key in Attributes.Name type
         let map = jvm.get_field(&this, "map", "Ljava/util/Map;").await?;
@@ -65,7 +65,7 @@ impl Attributes {
         this: ClassInstanceRef<Self>,
         name: ClassInstanceRef<String>,
     ) -> Result<ClassInstanceRef<String>> {
-        tracing::debug!("java.util.jar.Attributes::getValue({:?}, {:?})", &this, &name);
+        tracing::debug!("java.util.jar.Attributes::getValue({this:?}, {name:?})");
 
         let map = jvm.get_field(&this, "map", "Ljava/util/Map;").await?;
         let value = jvm.invoke_virtual(&map, "get", "(Ljava/lang/Object;)Ljava/lang/Object;", (name,)).await?;

--- a/java_runtime/src/classes/java/util/jar/jar_entry.rs
+++ b/java_runtime/src/classes/java/util/jar/jar_entry.rs
@@ -26,7 +26,7 @@ impl JarEntry {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, entry: ClassInstanceRef<ZipEntry>) -> Result<()> {
-        tracing::debug!("java.util.zip.ZipEntry::<init>({:?}, {:?})", &this, &entry,);
+        tracing::debug!("java.util.zip.ZipEntry::<init>({this:?}, {entry:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/util/zip/ZipEntry", "<init>", "(Ljava/util/zip/ZipEntry;)V", (entry,))

--- a/java_runtime/src/classes/java/util/jar/jar_entry.rs
+++ b/java_runtime/src/classes/java/util/jar/jar_entry.rs
@@ -26,7 +26,7 @@ impl JarEntry {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, entry: ClassInstanceRef<ZipEntry>) -> Result<()> {
-        tracing::debug!("java.util.zip.ZipEntry::<init>({this:?}, {entry:?})");
+        tracing::debug!("java.util.jar.JarEntry::<init>({this:?}, {entry:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/util/zip/ZipEntry", "<init>", "(Ljava/util/zip/ZipEntry;)V", (entry,))

--- a/java_runtime/src/classes/java/util/jar/jar_file.rs
+++ b/java_runtime/src/classes/java/util/jar/jar_file.rs
@@ -43,7 +43,7 @@ impl JarFile {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, file: ClassInstanceRef<File>) -> Result<()> {
-        tracing::debug!("java.util.jar.JarFile::<init>({:?}, {:?})", &this, &file,);
+        tracing::debug!("java.util.jar.JarFile::<init>({this:?}, {file:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/util/zip/ZipFile", "<init>", "(Ljava/io/File;)V", (file,))
@@ -53,7 +53,7 @@ impl JarFile {
     }
 
     async fn init_with_string(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, name: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.util.jar.JarFile::<init>({:?}, {:?})", &this, &name,);
+        tracing::debug!("java.util.jar.JarFile::<init>({this:?}, {name:?})");
 
         let file = jvm.new_class("java/io/File", "(Ljava/lang/String;)V", (name,)).await?;
 
@@ -70,7 +70,7 @@ impl JarFile {
         this: ClassInstanceRef<Self>,
         name: ClassInstanceRef<String>,
     ) -> Result<ClassInstanceRef<JarEntry>> {
-        tracing::debug!("java.util.jar.JarFile::getJarEntry({:?}, {:?})", &this, &name);
+        tracing::debug!("java.util.jar.JarFile::getJarEntry({this:?}, {name:?})");
 
         let zip_entry: ClassInstanceRef<ZipEntry> = jvm
             .invoke_virtual(&this, "getEntry", "(Ljava/lang/String;)Ljava/util/zip/ZipEntry;", (name,))
@@ -88,7 +88,7 @@ impl JarFile {
     }
 
     async fn entries(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<Enumeration>> {
-        tracing::debug!("java.util.jar.JarFile::entries({:?})", &this);
+        tracing::debug!("java.util.jar.JarFile::entries({this:?})");
 
         let zip_entries: ClassInstanceRef<Enumeration> = jvm
             .invoke_special(&this, "java/util/zip/ZipFile", "entries", "()Ljava/util/Enumeration;", ())
@@ -102,7 +102,7 @@ impl JarFile {
     }
 
     async fn get_manifest(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<Manifest>> {
-        tracing::debug!("java.util.jar.JarFile::getManifest({:?})", &this);
+        tracing::debug!("java.util.jar.JarFile::getManifest({this:?})");
 
         let manifest_name = JavaLangString::from_rust_string(jvm, "META-INF/MANIFEST.MF").await?;
         let manifest_file: ClassInstanceRef<JarEntry> = jvm

--- a/java_runtime/src/classes/java/util/jar/jar_file_entries.rs
+++ b/java_runtime/src/classes/java/util/jar/jar_file_entries.rs
@@ -31,7 +31,7 @@ impl JarFileEntries {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, entries: ClassInstanceRef<ZipFileEntries>) -> Result<()> {
-        tracing::debug!("java.util.jar.JarFile$Entries::<init>({:?}, {:?})", &this, &entries,);
+        tracing::debug!("java.util.jar.JarFile$Entries::<init>({this:?}, {entries:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -41,7 +41,7 @@ impl JarFileEntries {
     }
 
     async fn has_more_elements(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<bool> {
-        tracing::debug!("java.util.jar.JarFile$Entries::hasMoreElements({:?})", &this);
+        tracing::debug!("java.util.jar.JarFile$Entries::hasMoreElements({this:?})");
 
         let entries = jvm.get_field(&this, "entries", "Ljava/util/zip/ZipFile$Entries;").await?;
 
@@ -49,7 +49,7 @@ impl JarFileEntries {
     }
 
     async fn next_element(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<Object>> {
-        tracing::debug!("java.util.jar.JarFile$Entries::nextElement({:?})", &this);
+        tracing::debug!("java.util.jar.JarFile$Entries::nextElement({this:?})");
 
         let entries = jvm.get_field(&this, "entries", "Ljava/util/zip/ZipFile$Entries;").await?;
 

--- a/java_runtime/src/classes/java/util/jar/manifest.rs
+++ b/java_runtime/src/classes/java/util/jar/manifest.rs
@@ -33,7 +33,7 @@ impl Manifest {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, is: ClassInstanceRef<InputStream>) -> Result<()> {
-        tracing::debug!("java.util.jar.Manifest::<init>({:?}, {:?})", &this, &is);
+        tracing::debug!("java.util.jar.Manifest::<init>({this:?}, {is:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -43,7 +43,7 @@ impl Manifest {
     }
 
     async fn read(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, is: ClassInstanceRef<InputStream>) -> Result<()> {
-        tracing::debug!("java.util.jar.Manifest::read({:?}, {:?})", &this, &is);
+        tracing::debug!("java.util.jar.Manifest::read({this:?}, {is:?})");
 
         // TODO we currently support only main attribute
 
@@ -85,7 +85,7 @@ impl Manifest {
     }
 
     async fn get_main_attributes(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<Attributes>> {
-        tracing::debug!("java.util.jar.Manifest::getMainAttributes({:?})", &this);
+        tracing::debug!("java.util.jar.Manifest::getMainAttributes({this:?})");
 
         jvm.get_field(&this, "attrs", "Ljava/util/jar/Attributes;").await
     }

--- a/java_runtime/src/classes/java/util/no_such_element_exception.rs
+++ b/java_runtime/src/classes/java/util/no_such_element_exception.rs
@@ -24,7 +24,7 @@ impl NoSuchElementException {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.util.NoSuchElementException::<init>({:?})", &this);
+        tracing::debug!("java.util.NoSuchElementException::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/RuntimeException", "<init>", "()V", ()).await?;
 
@@ -32,7 +32,7 @@ impl NoSuchElementException {
     }
 
     async fn init_with_message(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, message: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.util.NoSuchElementException::<init>({:?}, {:?})", &this, &message);
+        tracing::debug!("java.util.NoSuchElementException::<init>({this:?}, {message:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/lang/RuntimeException", "<init>", "(Ljava/lang/String;)V", (message,))

--- a/java_runtime/src/classes/java/util/properties.rs
+++ b/java_runtime/src/classes/java/util/properties.rs
@@ -38,7 +38,7 @@ impl Properties {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.util.Properties::<init>({:?})", &this);
+        tracing::debug!("java.util.Properties::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/util/Hashtable", "<init>", "()V", ()).await?;
 
@@ -51,7 +51,7 @@ impl Properties {
         this: ClassInstanceRef<Self>,
         key: ClassInstanceRef<String>,
     ) -> Result<ClassInstanceRef<String>> {
-        tracing::debug!("java.util.Properties::getProperty({:?}, {:?})", &this, &key);
+        tracing::debug!("java.util.Properties::getProperty({this:?}, {key:?})");
 
         let result = jvm.invoke_virtual(&this, "get", "(Ljava/lang/Object;)Ljava/lang/Object;", (key,)).await?;
 
@@ -67,7 +67,7 @@ impl Properties {
         key: ClassInstanceRef<String>,
         value: ClassInstanceRef<String>,
     ) -> Result<ClassInstanceRef<Object>> {
-        tracing::debug!("java.util.Properties::setProperty({:?}, {:?}, {:?})", &this, &key, &value);
+        tracing::debug!("java.util.Properties::setProperty({this:?}, {key:?}, {value:?})");
 
         let old = jvm
             .invoke_virtual(&this, "put", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;", (key, value))

--- a/java_runtime/src/classes/java/util/random.rs
+++ b/java_runtime/src/classes/java/util/random.rs
@@ -26,7 +26,7 @@ impl Random {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.util.Random::<init>({:?})", &this);
+        tracing::debug!("java.util.Random::<init>({this:?})");
 
         let default_seed = 0i64; // TODO
         let _: () = jvm.invoke_special(&this, "java/util/Random", "<init>", "(J)V", (default_seed,)).await?;
@@ -35,7 +35,7 @@ impl Random {
     }
 
     async fn init_with_seed(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, seed: i64) -> Result<()> {
-        tracing::debug!("java.util.Random::<init>({:?}, {:?})", &this, seed);
+        tracing::debug!("java.util.Random::<init>({this:?}, {seed:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -45,7 +45,7 @@ impl Random {
     }
 
     async fn next_int(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>) -> Result<i32> {
-        tracing::debug!("java.util.Random::nextInt({:?})", &this);
+        tracing::debug!("java.util.Random::nextInt({this:?})");
 
         let seed: i64 = jvm.get_field(&this, "seed", "J").await?;
         let next_seed = seed.wrapping_mul(0x5DEECE66D).wrapping_add(0xB) & 0xFFFFFFFFFFFF;
@@ -58,7 +58,7 @@ impl Random {
     }
 
     async fn set_seed(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, seed: i64) -> Result<()> {
-        tracing::debug!("java.util.Random::setSeed({:?}, {:?})", &this, seed);
+        tracing::debug!("java.util.Random::setSeed({this:?}, {seed:?})");
 
         let seed = (seed ^ 0x5DEECE66D) & ((1 << 48) - 1);
 

--- a/java_runtime/src/classes/java/util/stack.rs
+++ b/java_runtime/src/classes/java/util/stack.rs
@@ -28,7 +28,7 @@ impl Stack {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::warn!("java.util.Stack::<init>({:?})", &this);
+        tracing::warn!("java.util.Stack::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/util/Vector", "<init>", "()V", ()).await?;
 
@@ -36,7 +36,7 @@ impl Stack {
     }
 
     async fn empty(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<bool> {
-        tracing::warn!("java.util.Stack::size({:?})", &this);
+        tracing::warn!("java.util.Stack::size({this:?})");
 
         let size: i32 = jvm.invoke_virtual(&this, "size", "()I", ()).await?;
         let is_empty = size == 0;
@@ -45,7 +45,7 @@ impl Stack {
     }
 
     async fn peek(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<Object>> {
-        tracing::warn!("java.util.Stack::peek({:?})", &this);
+        tracing::warn!("java.util.Stack::peek({this:?})");
 
         let size: i32 = jvm.invoke_virtual(&this, "size", "()I", ()).await?;
         if size == 0 {
@@ -57,7 +57,7 @@ impl Stack {
     }
 
     async fn pop(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<Object>> {
-        tracing::warn!("java.util.Stack::pop({:?})", &this);
+        tracing::warn!("java.util.Stack::pop({this:?})");
 
         let size: i32 = jvm.invoke_virtual(&this, "size", "()I", ()).await?;
         let element = jvm.invoke_virtual(&this, "peek", "()Ljava/lang/Object;", ()).await?;
@@ -72,7 +72,7 @@ impl Stack {
         this: ClassInstanceRef<Self>,
         element: ClassInstanceRef<Object>,
     ) -> Result<ClassInstanceRef<Object>> {
-        tracing::warn!("java.util.Stack::push({:?}, {:?})", &this, &element);
+        tracing::warn!("java.util.Stack::push({this:?}, {element:?})");
 
         let _: () = jvm
             .invoke_virtual(&this, "addElement", "(Ljava/lang/Object;)V", (element.clone(),))
@@ -82,7 +82,7 @@ impl Stack {
     }
 
     async fn search(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, element: ClassInstanceRef<Object>) -> Result<i32> {
-        tracing::warn!("java.util.Stack::search({:?}, {:?})", &this, &element);
+        tracing::warn!("java.util.Stack::search({this:?}, {element:?})");
 
         let i: i32 = jvm.invoke_virtual(&this, "lastIndexOf", "(Ljava/lang/Object;)I", (element,)).await?;
 

--- a/java_runtime/src/classes/java/util/time_zone.rs
+++ b/java_runtime/src/classes/java/util/time_zone.rs
@@ -30,7 +30,7 @@ impl TimeZone {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.util.TimeZone::<init>({:?})", &this);
+        tracing::debug!("java.util.TimeZone::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 

--- a/java_runtime/src/classes/java/util/timer.rs
+++ b/java_runtime/src/classes/java/util/timer.rs
@@ -36,7 +36,7 @@ impl Timer {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.util.Timer::<init>({:?})", &this);
+        tracing::debug!("java.util.Timer::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -61,7 +61,7 @@ impl Timer {
         delay: i64,
         period: i64,
     ) -> Result<()> {
-        tracing::debug!("java.util.Timer::schedule({:?}, {:?}, {:?}, {:?})", &this, &task, delay, period);
+        tracing::debug!("java.util.Timer::schedule({this:?}, {task:?}, {delay:?}, {period:?})");
 
         let now: i64 = context.now() as i64;
         let next_execution_time = now + delay;
@@ -77,13 +77,7 @@ impl Timer {
         delay: i64,
         period: i64,
     ) -> Result<()> {
-        tracing::debug!(
-            "java.util.Timer::scheduleAtFixedRate({:?}, {:?}, {:?}, {:?})",
-            &this,
-            &task,
-            delay,
-            period
-        );
+        tracing::debug!("java.util.Timer::scheduleAtFixedRate({this:?}, {task:?}, {delay:?}, {period:?})");
         // FIXME: fixed rate is not different from normal rate
 
         let now: i64 = context.now() as i64;

--- a/java_runtime/src/classes/java/util/timer_task.rs
+++ b/java_runtime/src/classes/java/util/timer_task.rs
@@ -28,7 +28,7 @@ impl TimerTask {
     }
 
     async fn init(jvm: &Jvm, _context: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.util.TimerTask::<init>({:?})", &this);
+        tracing::debug!("java.util.TimerTask::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 

--- a/java_runtime/src/classes/java/util/timer_thread.rs
+++ b/java_runtime/src/classes/java/util/timer_thread.rs
@@ -25,7 +25,7 @@ impl TimerThread {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, tasks: ClassInstanceRef<Vector>) -> Result<()> {
-        tracing::debug!("java.util.Timer$TimerThread::<init>({:?})", &this);
+        tracing::debug!("java.util.Timer$TimerThread::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Thread", "<init>", "()V", ()).await?;
 
@@ -35,7 +35,7 @@ impl TimerThread {
     }
 
     async fn run(jvm: &Jvm, context: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("java.util.Timer$TimerThread::run({:?})", &this);
+        tracing::debug!("java.util.Timer$TimerThread::run({this:?})");
 
         let java_tasks = jvm.get_field(&this, "tasks", "Ljava/util/Vector;").await?;
 

--- a/java_runtime/src/classes/java/util/zip/zip_entry.rs
+++ b/java_runtime/src/classes/java/util/zip/zip_entry.rs
@@ -30,7 +30,7 @@ impl ZipEntry {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, name: ClassInstanceRef<String>) -> Result<()> {
-        tracing::debug!("java.util.zip.ZipEntry::<init>({:?}, {:?})", &this, &name,);
+        tracing::debug!("java.util.zip.ZipEntry::<init>({this:?}, {name:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -45,7 +45,7 @@ impl ZipEntry {
         mut this: ClassInstanceRef<Self>,
         zip_entry: ClassInstanceRef<Self>,
     ) -> Result<()> {
-        tracing::debug!("java.util.zip.ZipEntry::<init>({:?}, {:?})", &this, &zip_entry,);
+        tracing::debug!("java.util.zip.ZipEntry::<init>({this:?}, {zip_entry:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -59,13 +59,13 @@ impl ZipEntry {
     }
 
     async fn get_name(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<String>> {
-        tracing::debug!("java.util.zip.ZipEntry::getName({:?})", &this);
+        tracing::debug!("java.util.zip.ZipEntry::getName({this:?})");
 
         jvm.get_field(&this, "name", "Ljava/lang/String;").await
     }
 
     async fn set_size(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, size: i64) -> Result<()> {
-        tracing::debug!("java.util.zip.ZipEntry::setSize({:?}, {:?})", &this, &size);
+        tracing::debug!("java.util.zip.ZipEntry::setSize({this:?}, {size:?})");
 
         jvm.put_field(&mut this, "size", "J", size).await?;
 
@@ -73,7 +73,7 @@ impl ZipEntry {
     }
 
     async fn get_size(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<i64> {
-        tracing::debug!("java.util.zip.ZipEntry::getSize({:?})", &this);
+        tracing::debug!("java.util.zip.ZipEntry::getSize({this:?})");
 
         jvm.get_field(&this, "size", "J").await
     }

--- a/java_runtime/src/classes/java/util/zip/zip_file.rs
+++ b/java_runtime/src/classes/java/util/zip/zip_file.rs
@@ -58,7 +58,7 @@ impl ZipFile {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>, file: ClassInstanceRef<File>) -> Result<()> {
-        tracing::debug!("java.util.zip.ZipFile::<init>({:?}, {:?})", &this, &file,);
+        tracing::debug!("java.util.zip.ZipFile::<init>({this:?}, {file:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -79,7 +79,7 @@ impl ZipFile {
         this: ClassInstanceRef<Self>,
         name: ClassInstanceRef<String>,
     ) -> Result<ClassInstanceRef<ZipEntry>> {
-        tracing::debug!("java.util.zip.ZipFile::getEntry({:?}, {:?})", &this, &name);
+        tracing::debug!("java.util.zip.ZipFile::getEntry({this:?}, {name:?})");
 
         let entry = jvm.new_class("java/util/zip/ZipEntry", "(Ljava/lang/String;)V", (name.clone(),)).await?;
         let name = JavaLangString::to_rust_string(jvm, &name).await?;
@@ -97,7 +97,7 @@ impl ZipFile {
     }
 
     async fn entries(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<Enumeration>> {
-        tracing::debug!("java.util.zip.ZipFile::entries({:?})", &this);
+        tracing::debug!("java.util.zip.ZipFile::entries({this:?})");
 
         let zip = Self::get_zip_archive(jvm, &this).await?;
         let names = zip.file_names().map(|x| x.to_string()).collect::<Vec<_>>();
@@ -125,7 +125,7 @@ impl ZipFile {
         this: ClassInstanceRef<Self>,
         entry: ClassInstanceRef<ZipEntry>,
     ) -> Result<ClassInstanceRef<InputStream>> {
-        tracing::debug!("java.util.zip.ZipFile::getInputStream({:?}, {:?})", &this, &entry);
+        tracing::debug!("java.util.zip.ZipFile::getInputStream({this:?}, {entry:?})");
 
         let entry_name = jvm.invoke_virtual(&entry, "getName", "()Ljava/lang/String;", ()).await?;
         let entry_name = JavaLangString::to_rust_string(jvm, &entry_name).await?;

--- a/java_runtime/src/classes/java/util/zip/zip_file_entries.rs
+++ b/java_runtime/src/classes/java/util/zip/zip_file_entries.rs
@@ -41,7 +41,7 @@ impl ZipFileEntries {
         zip_file: ClassInstanceRef<ZipFile>,
         names: ClassInstanceRef<Array<String>>,
     ) -> Result<()> {
-        tracing::debug!("java.util.zip.ZipFile$Entries::<init>({:?}, {:?})", &this, &zip_file,);
+        tracing::debug!("java.util.zip.ZipFile$Entries::<init>({this:?}, {zip_file:?})");
 
         let _: () = jvm.invoke_special(&this, "java/lang/Object", "<init>", "()V", ()).await?;
 
@@ -53,7 +53,7 @@ impl ZipFileEntries {
     }
 
     async fn has_more_elements(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<bool> {
-        tracing::debug!("java.util.zip.ZipFile$Entries::hasMoreElements({:?})", &this);
+        tracing::debug!("java.util.zip.ZipFile$Entries::hasMoreElements({this:?})");
 
         let i: i32 = jvm.get_field(&this, "i", "I").await?;
         let names: ClassInstanceRef<Array<String>> = jvm.get_field(&this, "names", "[Ljava/lang/String;").await?;
@@ -63,7 +63,7 @@ impl ZipFileEntries {
     }
 
     async fn next_element(jvm: &Jvm, _: &mut RuntimeContext, mut this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<Object>> {
-        tracing::debug!("java.util.zip.ZipFile$Entries::nextElement({:?})", &this);
+        tracing::debug!("java.util.zip.ZipFile$Entries::nextElement({this:?})");
 
         let i: i32 = jvm.get_field(&this, "i", "I").await?;
         let names: ClassInstanceRef<Array<String>> = jvm.get_field(&this, "names", "[Ljava/lang/String;").await?;

--- a/java_runtime/src/classes/org/rustjava/net/file_url_connection.rs
+++ b/java_runtime/src/classes/org/rustjava/net/file_url_connection.rs
@@ -36,7 +36,7 @@ impl FileURLConnection {
         url: ClassInstanceRef<URL>,
         file: ClassInstanceRef<File>,
     ) -> Result<()> {
-        tracing::debug!("org.rustjava.net.FileURLConnection::<init>({:?}, {:?}, {:?})", &this, &url, &file);
+        tracing::debug!("org.rustjava.net.FileURLConnection::<init>({this:?}, {url:?}, {file:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/net/URLConnection", "<init>", "(Ljava/net/URL;)V", (url,))
@@ -48,7 +48,7 @@ impl FileURLConnection {
     }
 
     async fn get_input_stream(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<InputStream>> {
-        tracing::debug!("org.rustjava.net.FileURLConnection::getInputStream({:?})", &this);
+        tracing::debug!("org.rustjava.net.FileURLConnection::getInputStream({this:?})");
 
         let file: ClassInstanceRef<File> = jvm.get_field(&this, "file", "Ljava/io/File;").await?;
         let file_input_stream = jvm.new_class("java/io/FileInputStream", "(Ljava/io/File;)V", (file,)).await?;

--- a/java_runtime/src/classes/org/rustjava/net/file_url_handler.rs
+++ b/java_runtime/src/classes/org/rustjava/net/file_url_handler.rs
@@ -35,7 +35,7 @@ impl FileURLHandler {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("org.rustjava.net.FileURLHandler::<init>({:?})", &this);
+        tracing::debug!("org.rustjava.net.FileURLHandler::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/net/URLStreamHandler", "<init>", "()V", ()).await?;
 
@@ -48,7 +48,7 @@ impl FileURLHandler {
         this: ClassInstanceRef<Self>,
         url: ClassInstanceRef<URL>,
     ) -> Result<ClassInstanceRef<URLConnection>> {
-        tracing::debug!("org.rustjava.net.FileURLHandler::openConnection({:?}, {:?})", &this, &url);
+        tracing::debug!("org.rustjava.net.FileURLHandler::openConnection({this:?}, {url:?})");
 
         let file: ClassInstanceRef<String> = jvm.invoke_virtual(&url, "getFile", "()Ljava/lang/String;", ()).await?;
         let file = jvm.new_class("java/io/File", "(Ljava/lang/String;)V", (file,)).await?;

--- a/java_runtime/src/classes/org/rustjava/net/jar_url_connection.rs
+++ b/java_runtime/src/classes/org/rustjava/net/jar_url_connection.rs
@@ -45,7 +45,7 @@ impl JarURLConnection {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>, url: ClassInstanceRef<URL>) -> Result<()> {
-        tracing::debug!("org.rustjava.net.JarURLConnection::<init>({:?}, {:?})", &this, &url);
+        tracing::debug!("org.rustjava.net.JarURLConnection::<init>({this:?}, {url:?})");
 
         let _: () = jvm
             .invoke_special(&this, "java/net/JarURLConnection", "<init>", "(Ljava/net/URL;)V", (url.clone(),))
@@ -55,7 +55,7 @@ impl JarURLConnection {
     }
 
     async fn get_jar_file(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<JarFile>> {
-        tracing::debug!("org.rustjava.net.JarURLConnection::getJarFile({:?})", &this);
+        tracing::debug!("org.rustjava.net.JarURLConnection::getJarFile({this:?})");
 
         let url = jvm.invoke_virtual(&this, "getJarFileURL", "()Ljava/net/URL;", ()).await?;
         let protocol = jvm.invoke_virtual(&url, "getProtocol", "()Ljava/lang/String;", ()).await?;
@@ -94,7 +94,7 @@ impl JarURLConnection {
     }
 
     async fn get_input_stream(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<ClassInstanceRef<InputStream>> {
-        tracing::debug!("org.rustjava.net.JarURLConnection::getInputStream({:?})", &this);
+        tracing::debug!("org.rustjava.net.JarURLConnection::getInputStream({this:?})");
 
         let entry: ClassInstanceRef<String> = jvm.invoke_virtual(&this, "getEntryName", "()Ljava/lang/String;", ()).await?;
         let jar_file = jvm.invoke_virtual(&this, "getJarFile", "()Ljava/util/jar/JarFile;", ()).await?;

--- a/java_runtime/src/classes/org/rustjava/net/jar_url_handler.rs
+++ b/java_runtime/src/classes/org/rustjava/net/jar_url_handler.rs
@@ -32,7 +32,7 @@ impl JarURLHandler {
     }
 
     async fn init(jvm: &Jvm, _: &mut RuntimeContext, this: ClassInstanceRef<Self>) -> Result<()> {
-        tracing::debug!("org.rustjava.net.JarURLHandler::<init>({:?})", &this);
+        tracing::debug!("org.rustjava.net.JarURLHandler::<init>({this:?})");
 
         let _: () = jvm.invoke_special(&this, "java/net/URLStreamHandler", "<init>", "()V", ()).await?;
 
@@ -45,7 +45,7 @@ impl JarURLHandler {
         this: ClassInstanceRef<Self>,
         url: ClassInstanceRef<URL>,
     ) -> Result<ClassInstanceRef<URLConnection>> {
-        tracing::debug!("org.rustjava.net.JarURLHandler::openConnection({:?}, {:?})", &this, &url);
+        tracing::debug!("org.rustjava.net.JarURLHandler::openConnection({this:?}, {url:?})");
 
         let connection = jvm.new_class("org/rustjava/net/JarURLConnection", "(Ljava/net/URL;)V", (url,)).await?;
 

--- a/jvm/src/jvm.rs
+++ b/jvm/src/jvm.rs
@@ -113,7 +113,7 @@ impl Jvm {
 
     #[async_recursion::async_recursion]
     pub async fn instantiate_class(&self, class_name: &str) -> Result<Box<dyn ClassInstance>> {
-        tracing::trace!("Instantiate {}", class_name);
+        tracing::trace!("Instantiate {class_name}");
 
         let class = self.resolve_class(class_name).await?;
 
@@ -153,7 +153,7 @@ impl Jvm {
     }
 
     pub async fn instantiate_array(&self, element_type_name: &str, length: usize) -> Result<Box<dyn ClassInstance>> {
-        tracing::trace!("Instantiate array of {} with length {}", element_type_name, length);
+        tracing::trace!("Instantiate array of {element_type_name} with length {length}");
 
         let class_name = format!("[{element_type_name}");
 
@@ -176,7 +176,7 @@ impl Jvm {
     where
         T: From<JavaValue>,
     {
-        tracing::trace!("Get static field {}.{}:{}", class_name, name, descriptor);
+        tracing::trace!("Get static field {class_name}.{name}:{descriptor}");
 
         let class = self.resolve_class(class_name).await?;
 
@@ -201,7 +201,7 @@ impl Jvm {
     where
         T: Into<JavaValue> + Debug,
     {
-        tracing::trace!("Put static field {}.{}:{} = {:?}", class_name, name, descriptor, value);
+        tracing::trace!("Put static field {class_name}.{name}:{descriptor} = {value:?}");
 
         let class = self.resolve_class(class_name).await?;
 
@@ -226,7 +226,7 @@ impl Jvm {
     where
         T: From<JavaValue>,
     {
-        tracing::trace!("Get field {}.{}:{}", instance.class_definition().name(), name, descriptor);
+        tracing::trace!("Get field {}.{name}:{descriptor}", instance.class_definition().name());
 
         let field = self.find_field(&*instance.class_definition(), name, descriptor)?;
 
@@ -246,7 +246,7 @@ impl Jvm {
     where
         T: Into<JavaValue> + Debug,
     {
-        tracing::trace!("Put field {}.{}:{} = {:?}", instance.class_definition().name(), name, descriptor, value);
+        tracing::trace!("Put field {}.{name}:{descriptor} = {value:?}", instance.class_definition().name());
 
         let field = self.find_field(&*instance.class_definition(), name, descriptor)?;
 
@@ -269,7 +269,7 @@ impl Jvm {
     {
         let args = args.into_arg();
 
-        tracing::trace!("Invoke static {}.{}:{}({:?})", class_name, name, descriptor, args);
+        tracing::trace!("Invoke static {class_name}.{name}:{descriptor}({args:?})");
 
         let class = self.resolve_class(class_name).await?;
 
@@ -284,7 +284,7 @@ impl Jvm {
 
             Ok(self.execute_method(&declaring_class, None, &method, args).await?.into())
         } else {
-            tracing::error!("No such method: {}.{}:{}", class_name, name, descriptor);
+            tracing::error!("No such method: {class_name}.{name}:{descriptor}");
 
             Err(self
                 .exception("java/lang/NoSuchMethodError", &format!("{class_name}.{name}:{descriptor}"))
@@ -298,13 +298,7 @@ impl Jvm {
         U: From<JavaValue>,
     {
         let args = args.into_arg();
-        tracing::trace!(
-            "Invoke virtual {}.{}:{}({:?})",
-            instance.class_definition().name(),
-            name,
-            descriptor,
-            args
-        );
+        tracing::trace!("Invoke virtual {}.{name}:{descriptor}({args:?})", instance.class_definition().name());
 
         let class = instance.class_definition();
         let method = self.find_virtual_method(&*class, name, descriptor, false)?;
@@ -319,7 +313,7 @@ impl Jvm {
                 .await?
                 .into())
         } else {
-            tracing::error!("No such method: {}.{}:{}", class.name(), name, descriptor);
+            tracing::error!("No such method: {}.{name}:{descriptor}", class.name());
 
             Err(self
                 .exception("java/lang/NoSuchMethodError", &format!("{}.{}:{}", class.name(), name, descriptor))
@@ -335,7 +329,7 @@ impl Jvm {
         U: From<JavaValue>,
     {
         let args = args.into_arg();
-        tracing::trace!("Invoke special {}.{}:{}({:?})", class_name, name, descriptor, args);
+        tracing::trace!("Invoke special {class_name}.{name}:{descriptor}({args:?})");
 
         let class = self.resolve_class(class_name).await?;
         let method = class.definition.method(name, descriptor, false);
@@ -368,7 +362,7 @@ impl Jvm {
         T: IntoIterator<Item = U> + Send,
         U: Into<JavaValue>,
     {
-        tracing::trace!("Store array {} at offset {}", array.class_definition().name(), offset);
+        tracing::trace!("Store array {} at offset {offset}", array.class_definition().name());
 
         let values = values.into_iter().map(|x| x.into()).collect::<Vec<_>>();
 
@@ -397,7 +391,7 @@ impl Jvm {
     where
         T: From<JavaValue>,
     {
-        tracing::trace!("Load array {} at offset {}", array.class_definition().name(), offset);
+        tracing::trace!("Load array {} at offset {offset}", array.class_definition().name());
 
         let array_size = self.array_length(array).await?;
         if offset + count > array_size {
@@ -540,7 +534,7 @@ impl Jvm {
 
     #[async_recursion::async_recursion]
     async fn resolve_class_internal(&self, class_name: &str, class_loader_wrapper: Option<&dyn ClassLoaderWrapper>) -> Result<Class> {
-        tracing::trace!("Resolving class {}", class_name);
+        tracing::trace!("Resolving class {class_name}");
         let class = self.inner.classes.read().get(class_name).cloned();
 
         if let Some(x) = class {
@@ -575,17 +569,17 @@ impl Jvm {
     }
 
     async fn load_class(&self, class_name: &str, class_loader_wrapper: &dyn ClassLoaderWrapper) -> Result<Class> {
-        tracing::debug!("Loading class {}", class_name);
+        tracing::debug!("Loading class {class_name}");
 
         let class = class_loader_wrapper.load_class(self, class_name).await?;
 
         if class.is_none() {
-            tracing::error!("No such class: {}", class_name);
+            tracing::error!("No such class: {class_name}");
 
             return Err(self.exception("java/lang/NoClassDefFoundError", class_name).await);
         }
 
-        tracing::debug!("Loaded class {}", class_name);
+        tracing::debug!("Loaded class {class_name}");
 
         Ok(class.unwrap())
     }
@@ -685,7 +679,7 @@ impl Jvm {
     }
 
     pub async fn exception(&self, r#type: &str, message: &str) -> JavaError {
-        tracing::info!("throwing java exception: {} {}", r#type, message);
+        tracing::info!("throwing java exception: {} {message}", r#type);
 
         let message_str = JavaLangString::from_rust_string(self, message).await.unwrap();
         let instance = self.new_class(r#type, "(Ljava/lang/String;)V", (message_str,)).await.unwrap();
@@ -728,11 +722,11 @@ impl Jvm {
 
         let garbage_count = garbage.len();
 
-        tracing::trace!("Garbage count: {}", garbage_count);
+        tracing::trace!("Garbage count: {garbage_count}");
 
         for object in garbage {
             let name = object.class_definition().name();
-            tracing::trace!("Destroying {:?}({})", object, name);
+            tracing::trace!("Destroying {object:?}({name})");
 
             self.destroy(object).unwrap();
         }
@@ -977,7 +971,7 @@ impl Jvm {
 
         let result = method.run(self, args).await;
 
-        tracing::trace!("Execute result: {:?}", result);
+        tracing::trace!("Execute result: {result:?}");
 
         self.inner.threads.write().get_mut(&thread_id).unwrap().pop_frame();
 

--- a/jvm_rust/src/interpreter.rs
+++ b/jvm_rust/src/interpreter.rs
@@ -38,7 +38,7 @@ impl Interpreter {
 
         let mut iter = code_attribute.code.range(0..);
         while let Some((offset, opcode)) = iter.next() {
-            tracing::trace!("Opcode {:?}", opcode);
+            tracing::trace!("Opcode {opcode:?}");
 
             let result = Self::execute_opcode(jvm, *offset, opcode, &mut stack_frame, return_type).await;
             match result {


### PR DESCRIPTION
## Summary

Converts `tracing` log calls from positional arguments to inline format captures across the codebase, e.g.:

```rust
tracing::debug!("java.lang.String::<init>({:?}, {:?})", &this, &value);
// becomes
tracing::debug!("java.lang.String::<init>({this:?}, {value:?})");
```

## Scope

Only bare-identifier arguments are inlined (optionally `&`-prefixed, since `Debug`/`Display` see through references). Conversion is **partial** where only some arguments qualify:

```rust
tracing::trace!("Get field {}.{}:{}", instance.class_definition().name(), name, descriptor);
// becomes
tracing::trace!("Get field {}.{name}:{descriptor}", instance.class_definition().name());
```

Left positional (cannot be captured inline):
- method calls / field accesses — `class.name()`, `instance.class_definition().name()`
- raw identifiers — `r#in`, `r#type`

This matches clippy's `uninlined_format_args` style.

## Test plan

- `cargo test --workspace` green, `cargo fmt --check` clean, `cargo clippy --workspace --all-targets` no new warnings (no remaining `uninlined_format_args`).
- Mechanical change; no behavior change (Debug/Display of `&x` and `x` are identical).